### PR TITLE
fix(react): remove unnecessary type in fallback

### DIFF
--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -22,7 +22,7 @@ type Props = PropsWithRef<
     resetKeys?: unknown[]
     onReset?(): void
     onError?(error: Error, info: ErrorInfo): void
-    fallback: ReactNode | ((props: { error: Error; reset: (...args: unknown[]) => void }) => ReactNode)
+    fallback: ReactNode | ((props: { error: Error; reset: () => void }) => ReactNode)
   }>
 >
 


### PR DESCRIPTION
 ### remove unnecessary type in fallback
I changed the factor of fallback's reset function as void 

fix #2 