### PR TITLE
ci: check lint on PR synchronized

### DIFF
--- a/.github/workflows/eslint-workflow.yml
+++ b/.github/workflows/eslint-workflow.yml
@@ -1,0 +1,20 @@
+name: 'Lint checking for typescript'
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: 'Checking Lint'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Test
+        run: pnpm lint


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Check the `lint` when PR is generated and updated. If the CI pipeline works for each commit, it will take a lot of time to refine the commit, so let the pipeline work for each PR😄

Originally, I used this [library](https://github.com/toss/yarn-plugin-workspace-since) to detect only modified package itself to execute the command of the lint check, so that only the package where the change occurred would be candidate of lint check.

However, I did not use the above [library](https://github.com/toss/yarn-plugin-workspace-since) because I thought that the `suspensive` uses [turborepo](https://turbo.build/) and the package that did not change due to the nature of [turborepo](https://turbo.build/) would omit the lint check.

If the lint check works unnecessarily on a package that has not even changed, I will improve it by using [library](https://github.com/toss/yarn-plugin-workspace-since)