### PR TITLE
docs: add pnpm install guide to intro page

### DIFF
--- a/websites/docs/intro/installation.en.md
+++ b/websites/docs/intro/installation.en.md
@@ -18,3 +18,11 @@ Or if you're using <a href="https://classic.yarnpkg.com/en/docs/install/" target
 ```shell
 yarn add @suspensive/react
 ```
+
+### pnpm
+
+Or if you're using <a href="https://pnpm.io/" target="_blank">pnpm</a>:
+
+```shell
+pnpm add @suspensive/react
+```

--- a/websites/docs/intro/installation.en.md
+++ b/websites/docs/intro/installation.en.md
@@ -24,5 +24,5 @@ yarn add @suspensive/react
 Or if you're using <a href="https://pnpm.io/" target="_blank">pnpm</a>:
 
 ```shell
-pnpm add @suspensive/react
+pnpm install @suspensive/react
 ```

--- a/websites/docs/intro/installation.ko.md
+++ b/websites/docs/intro/installation.ko.md
@@ -24,5 +24,5 @@ yarn add @suspensive/react
 혹은 <a href="https://pnpm.io/" target="_blank">pnpm</a>을 사용한다면:
 
 ```shell
-pnpm add @suspensive/react
+pnpm install @suspensive/react
 ```

--- a/websites/docs/intro/installation.ko.md
+++ b/websites/docs/intro/installation.ko.md
@@ -18,3 +18,11 @@ npm install @suspensive/react
 ```shell
 yarn add @suspensive/react
 ```
+
+### pnpm
+
+혹은 <a href="https://pnpm.io/" target="_blank">pnpm</a>을 사용한다면:
+
+```shell
+pnpm add @suspensive/react
+```


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

There is a pnpm installation guide on other pages such as https://docs.suspensive.org/docs/react/README.i18n and https://docs.suspensive.org/docs/react-query/README.i18n, so I also add a guide related to pnpm on the intro page to match the unity.