### PR TITLE
chore: make automation release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'configuration'
+      - 'documentation'
+      - 'websites/docs'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,52 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: get-react-version
+        id: package-version-react
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: packages/react
+
+      - uses: release-drafter/release-drafter@v5
+        with:
+          version: 'v${{ steps.package-version-react.outputs.current-version }}'
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: get-react-query-version
+        id: package-version-react-query
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: packages/react-query
+
+      - uses: release-drafter/release-drafter@v5
+        with:
+          version: 'v${{ steps.package-version-react-query.outputs.current-version }}'
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

fix: #16 

When pushed to the main branch, it reads the version of each package and creates a `github release draft`. After that, if you manually publish the draft, user can see changelog in release.

I tested in my repository so you can see [here!](https://github.com/ChanhyukPark-Tech/release-note-test/releases)

I think you can give me a suggestion about categories label!

# Screenshot

![image](https://user-images.githubusercontent.com/69495129/231519216-9e971e86-7ba6-4de7-b4de-93e8d73ca317.png)


 

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I have written documents and tests, if needed.
