### PR TITLE
chore(.changeset, .github/workflows): add auto generating CHANGELOG.md

### DIFF
--- a/.changeset/beige-ways-type.md
+++ b/.changeset/beige-ways-type.md
@@ -1,0 +1,6 @@
+---
+'@suspensive/react': patch
+'@suspensive/react-query': patch
+---
+
+changelog initialization

--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -1,0 +1,7 @@
+const { exec } = require('child_process')
+// This script is used by the `.github/workflows/release-workflow.yml` workflow to update the version of the packages being released.
+// The standard step is only to run `changeset version` but this does not update the pnpm-lock.yaml file.
+// So we also run `pnpm install`, which does this update.
+// See https://github.com/changesets/changesets/issues/421.
+exec('pnpm run changeset version')
+exec('pnpm install --lockfile-only')

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,4 +1,4 @@
-name: "Continuous Integration"
+name: ci-workflow
 
 on:
   pull_request:
@@ -6,13 +6,21 @@ on:
 
 jobs:
   quality:
-    name: "CI: Check quality"
+    name: Check quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 8
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.17'
+          check-latest: true
 
       - name: Install dependencies
         run: pnpm install
@@ -25,3 +33,6 @@ jobs:
 
       - name: Test by jest
         run: pnpm test
+
+      - name: Build package
+        run: pnpm run build

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,13 +17,13 @@ jobs:
           version: 8
 
       - name: Read .nvmrc
-         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-         id: nvm
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
           check-latest: true
 
       - name: Install dependencies

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,10 +16,14 @@ jobs:
         with:
           version: 8
 
+      - name: Read .nvmrc
+         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+         id: nvm
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16.17'
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
           check-latest: true
 
       - name: Install dependencies

--- a/.github/workflows/labeler-workflow.yml
+++ b/.github/workflows/labeler-workflow.yml
@@ -1,4 +1,5 @@
-name: "Pull Request Labeler"
+name: labeler-workflow
+
 on:
   - pull_request_target
 
@@ -8,4 +9,4 @@ jobs:
     steps:
       - uses: actions/labeler@main
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,55 @@
+name: release-workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Release to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 8
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.17
+          check-latest: true
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check typescript
+        run: pnpm type:check
+
+      - name: Check eslint
+        run: pnpm lint
+
+      - name: Test by jest
+        run: pnpm test
+
+      - name: Set git user
+        run: |
+          git config --global user.email "manudeli.ko@gmail.com"
+          git config --global user.name "Jonghyeon Ko"
+
+      - name: Create Changesets Pull Request or Publish to NPM
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          setupGitUser: false
+          title: 'chore(changesets): bump packages version'
+          commit: 'chore: bump packages version'
+          version: node .github/changeset-version.js
+          publish: pnpm npm:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -27,15 +27,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Check typescript
-        run: pnpm type:check
-
-      - name: Check eslint
-        run: pnpm lint
-
-      - name: Test by jest
-        run: pnpm test
-
       - name: Set git user
         run: |
           git config --global user.email "manudeli.ko@gmail.com"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -18,10 +18,14 @@ jobs:
         with:
           version: 8
 
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.17
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
           check-latest: true
 
       - name: Install dependencies


### PR DESCRIPTION
fix #16 

# Auto generating CHANGELOG.md
1. Using changeset bot in Pull Request
We can use changeset bot in Pull Request of every contributors to add `changeset log` that will make CHANGELOG.md
![image](https://user-images.githubusercontent.com/61593290/232260038-bfe970bd-914c-447f-b299-ba5e725a43b6.png)

2. When there is a new commit on the main branch, If there is `changeset log`(inside of .changeset/*), It will make new Pull Request to bump versions of all packages. like https://github.com/manudeli/monorepo-libraries-changeset-test/pull/3 containing auto updated CHANGELOG.md files of packages

3. Then, If we merge 2.'s Pull Request, Publishing to NPM workflow will starting. like https://github.com/manudeli/monorepo-libraries-changeset-test/actions/runs/4710530002

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I have written documents and tests, if needed.
