### PR TITLE
chore(.github/workflow): add cache, remove unnecessary type:check, node-version

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,30 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
         with:
           version: 8
-
-      - name: Read .nvmrc
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: nvm
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
-          check-latest: true
-
-      - name: Install dependencies
-        run: pnpm install
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+          node-version-file: '.nvmrc'
+      - run: pnpm install --frozen-lockfile
 
       - name: Build core packages
         run: pnpm build --filter=@suspensive/react --filter=@suspensive/react-query
-
-      - name: Check typescript
-        run: pnpm type:check
 
       - name: Check eslint
         run: pnpm lint

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -10,26 +10,16 @@ jobs:
     name: Release to NPM
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
         with:
           version: 8
-
-      - name: Read .nvmrc
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: nvm
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
-          check-latest: true
-
-      - name: Install dependencies
-        run: pnpm install
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+          node-version-file: '.nvmrc'
+      - run: pnpm install --frozen-lockfile
 
       - name: Set git user
         run: |


### PR DESCRIPTION
# add cache, remove unnecessary type:check, node-version in .github/workflows
I left comment to explain details.

## Check difference

### No cache(1m 59s)
![image](https://user-images.githubusercontent.com/61593290/236897963-c2ed6022-462e-4233-a5dd-ce2f1b93b366.png)

### Cached(55s)
![image](https://user-images.githubusercontent.com/61593290/236898092-d16a8b3c-3872-43a9-b654-4cd36ab77287.png)


<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I have written documents and tests, if needed.
