### PR TITLE
chore(react-query): fix LICENSE.md in @suspensive/react-query to conform MIT license of toss/slash

### DIFF
--- a/.changeset/brown-actors-sniff.md
+++ b/.changeset/brown-actors-sniff.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react-query": patch
+---
+
+chore(react-query): fix LICENSE.md in @suspensive/react-query to conform MIT license of toss/slash

--- a/packages/react-query/LICENSE
+++ b/packages/react-query/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2021 Viva Republica, Inc.
 Copyright (c) 2023 Suspensive
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
fix #37 

# Fix LICENSE.md in @suspensive/react-query
With this PR(https://github.com/TanStack/query/pull/5259), Documentation of @suspensive/react-query was added to the Community Resources section of TanStack/query's official documentation, and then reverted by @BasixKOR's this PR(https://github.com/TanStack/query/pull/5303)

The reason we discussed was that @suspensive/react-query started from the code of @toss/react-query, but we didn't mark it in LICENSE.md.

### so What I followed (@raon0211's guide)
https://gist.github.com/fbaierl/1d740a7925a6e0e608824eb27a429370