### PR TITLE
fix(react-query): add @suspensive/react as peerDependenciesMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ npm install @suspensive/react
 ```
 
 ```shell
-yarn add @suspensive/react
+pnpm add @suspensive/react
 ```
 
 ```shell
-pnpm add @suspensive/react
+yarn add @suspensive/react
 ```
 
 ## Usage
@@ -94,15 +94,15 @@ Declarative apis to use [@tanstack/react-query with suspense](https://tanstack.c
 ## Installation
 
 ```shell
-npm install @suspensive/react @suspensive/react-query
+npm install @suspensive/react-query
 ```
 
 ```shell
-yarn add @suspensive/react @suspensive/react-query
+pnpm add @suspensive/react-query
 ```
 
 ```shell
-pnpm add @suspensive/react @suspensive/react-query
+yarn add @suspensive/react-query
 ```
 
 ## Usage

--- a/packages/react-query/README.ko.md
+++ b/packages/react-query/README.ko.md
@@ -9,13 +9,13 @@
 @suspensive/react-query 는 npm에 있습니다. 최신 안정버전을 설치하기 위해 아래 커맨드를 실행하세요
 
 ```shell
-npm install @suspensive/react @suspensive/react-query
+npm install @suspensive/react-query
 ```
 
 ```shell
-yarn add @suspensive/react @suspensive/react-query
+pnpm add @suspensive/react-query
 ```
 
 ```shell
-pnpm add @suspensive/react @suspensive/react-query
+yarn add @suspensive/react-query
 ```

--- a/packages/react-query/README.md
+++ b/packages/react-query/README.md
@@ -9,13 +9,13 @@
 @suspensive/react-query lives in npm. To install the latest stable version, run the following command
 
 ```shell
-npm install @suspensive/react @suspensive/react-query
+npm install @suspensive/react-query
 ```
 
 ```shell
-yarn add @suspensive/react @suspensive/react-query
+pnpm add @suspensive/react-query
 ```
 
 ```shell
-pnpm add @suspensive/react @suspensive/react-query
+yarn add @suspensive/react-query
 ```

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -65,6 +65,11 @@
     "@tanstack/react-query": "^4",
     "react": "^16.8 || ^17 || ^18"
   },
+  "peerDependenciesMeta": {
+    "@suspensive/react": {
+      "optional": true
+    }
+  },
   "bundledDependencies": [
     "tsd"
   ],

--- a/packages/react-query/src/QueryAsyncBoundary.tsx
+++ b/packages/react-query/src/QueryAsyncBoundary.tsx
@@ -44,6 +44,19 @@ if (process.env.NODE_ENV !== 'production') {
 /**
  * This component wrapping QueryErrorResetBoundary of @tanstack/react-query with @suspensive/react's AsyncBoundary.
  *
+ * So you must install @suspensive/react first, then use it.
+ * ```shell
+ * npm install @suspensive/react @suspensive/react-query
+ * ```
+ *
+ * ```shell
+ * pnpm add @suspensive/react @suspensive/react-query
+ * ```
+ *
+ * ```shell
+ * yarn add @suspensive/react @suspensive/react-query
+ * ```
+ *
  * with this component, You don't have to make unnecessary repetitive implementation to combine AsyncBoundary with QueryErrorResetBoundary
  * @see {@link https://suspensive.org/docs/react-query/src/QueryErrorResetBoundary.i18n Suspensive Official Docs}
  */

--- a/packages/react-query/src/QueryErrorBoundary.tsx
+++ b/packages/react-query/src/QueryErrorBoundary.tsx
@@ -5,6 +5,19 @@ import { useQueryErrorResetBoundary } from '@tanstack/react-query'
 /**
  * This component wrapping QueryErrorResetBoundary of @tanstack/react-query with @suspensive/react's ErrorBoundary.
  *
+ * So you must install @suspensive/react first, then use it.
+ * ```shell
+ * npm install @suspensive/react @suspensive/react-query
+ * ```
+ *
+ * ```shell
+ * pnpm add @suspensive/react @suspensive/react-query
+ * ```
+ *
+ * ```shell
+ * yarn add @suspensive/react @suspensive/react-query
+ * ```
+ *
  * with this component, You don't have to make unnecessary repetitive implementation to combine ErrorBoundary with QueryErrorResetBoundary
  * @see {@link https://suspensive.org/docs/react-query/src/QueryErrorResetBoundary.i18n Suspensive Official Docs}
  */

--- a/packages/react-query/src/QueryErrorResetBoundary.en.mdx
+++ b/packages/react-query/src/QueryErrorResetBoundary.en.mdx
@@ -44,6 +44,23 @@ const Example = () => (
 )
 ```
 
+### peerDependency
+
+Below apis (QueryErrorBoundary, QueryAsyncBoundary) have peerDependency on @suspensive/react's ErrorBoundary, AsyncBoundary.
+So if you want to use these, you must install @suspensive/react first.
+
+```shell
+npm install @suspensive/react @suspensive/react-query
+```
+
+```shell
+pnpm add @suspensive/react @suspensive/react-query
+```
+
+```shell
+yarn add @suspensive/react @suspensive/react-query
+```
+
 @suspensive/react-query provide QueryErrorBoundary, QueryAsyncBoundary to reduce repeating implementation like using QueryErrorResetBoundary + ErrorBoundary, QueryErrorResetBoundary + AsyncBoundary.
 
 ## QueryErrorBoundary

--- a/packages/react-query/src/QueryErrorResetBoundary.ko.mdx
+++ b/packages/react-query/src/QueryErrorResetBoundary.ko.mdx
@@ -43,6 +43,24 @@ const Example = () => (
   </QueryErrorResetBoundary>
 )
 ```
+
+### peerDependency
+
+아래 api(QueryErrorBoundary, QueryAsyncBoundary)는 @suspensive/react의 ErrorBoundary, AsyncBoundary에 peerDependency를 갖습니다.
+따라서 이를 사용하려면 먼저 @suspensive/react를 설치해야 합니다.
+
+```shell
+npm install @suspensive/react @suspensive/react-query
+```
+
+```shell
+pnpm add @suspensive/react @suspensive/react-query
+```
+
+```shell
+yarn add @suspensive/react @suspensive/react-query
+```
+
 @suspensive/react-query는 QueryErrorResetBoundary + ErrorBoundary, QueryErrorResetBoundary + AsyncBoundary와 같은 반복되는 구현을 줄이기 위해 QueryErrorBoundary, QueryAsyncBoundary를 제공합니다.
 
 ## QueryErrorBoundary

--- a/packages/react/README.ko.md
+++ b/packages/react/README.ko.md
@@ -13,9 +13,9 @@ npm install @suspensive/react
 ```
 
 ```shell
-yarn add @suspensive/react
+pnpm add @suspensive/react
 ```
 
 ```shell
-pnpm add @suspensive/react
+yarn add @suspensive/react
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,9 +13,9 @@ npm install @suspensive/react
 ```
 
 ```shell
-yarn add @suspensive/react
+pnpm add @suspensive/react
 ```
 
 ```shell
-pnpm add @suspensive/react
+yarn add @suspensive/react
 ```


### PR DESCRIPTION
fix #46 

# Add @suspensive/react as peerDependenciesMeta of @suspensive/react-query
Users who only want to use @suspensive/react-query had to install @suspensive/react because it is a peerDependency.

I expect that allowing @suspensive/react-query to be used without installing @suspensive/react will allow more flexibility in accepting users, and as a result, @suspensive/react will be able to receive more users as well.

### peerDependenciesMeta
That's why I try to solve this problem with [peerDependenciesMeta](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependenciesmeta) in package.json.
Users of @suspensive/react-query are no longer required to install @suspensive/react.

It's nice to be flexible, but users of QueryErrorBoundary and QueryAsyncBoundary can get lost. Therefore, the official documentation and ts-doc guide users that they need to install @suspensive/react.

## PR Checklist

- [x] I have written documents and tests, if needed.
