### PR TITLE
chore(doc): add color scheme config to docs config

### DIFF
--- a/websites/docs/docusaurus.config.js
+++ b/websites/docs/docusaurus.config.js
@@ -148,6 +148,9 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
     }),
 }
 


### PR DESCRIPTION
# Overview

I add color scheme config to docusaurus.config.js [7d1753](https://github.com/suspensive/react/commit/7de17533002536586b9f2ca3719ef5e03812567f)

Using user system preferences, instead of the hardcoded ([referece](https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme))

## Screenshot


https://github.com/suspensive/react/assets/57122180/c888bf86-d86e-411f-abab-f79213a5e777



## PR Checklist

- [x] I have written documents and tests, if needed.
