### PR TITLE
fix(react): fix useErrorBoundaryGroup to guarantee parent ErrorBoundaryGroup

### DIFF
--- a/.changeset/thick-walls-talk.md
+++ b/.changeset/thick-walls-talk.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix(react): fix useErrorBoundaryGroup to guarantee parent ErrorBoundaryGroup

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,13 +3,13 @@ coverage:
     project:
       default:
         target: 100%
-        threshold: 20%
+        threshold: 30%
       suspensive-react:
         target: 100%
-        threshold: 20%
+        threshold: 30%
       suspensive-react-query:
         target: 100%
-        threshold: 20%
+        threshold: 30%
 
 comment:
   layout: "header, reach, diff, flags, components"

--- a/configs/tsconfig/react-library.json
+++ b/configs/tsconfig/react-library.json
@@ -4,7 +4,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["ES2015"],
+    "lib": ["DOM", "ES2015"],
     "module": "ESNext",
     "target": "es6"
   }

--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -1,0 +1,143 @@
+import { act } from '@testing-library/react'
+import { createRoot } from 'react-dom/client'
+import { ComponentProps, createRef, ComponentRef } from 'react'
+import { ErrorBoundary } from './ErrorBoundary'
+import { TEXT, MS_100, ThrowError, ERROR_MESSAGE, FALLBACK } from './test-utils'
+
+let container = document.createElement('div')
+let root = createRoot(container)
+const errorBoundaryRef = createRef<ComponentRef<typeof ErrorBoundary>>()
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    container = document.createElement('div')
+    root = createRoot(container)
+    ThrowError.reset()
+  })
+
+  const renderErrorBoundary = (props: Partial<ComponentProps<typeof ErrorBoundary>>) =>
+    act(() =>
+      root.render(
+        <ErrorBoundary ref={errorBoundaryRef} fallback={(caught) => <>{caught.error.message}</>} {...props} />
+      )
+    )
+
+  it('should show children if no error but if error in children, catch it and show fallback and call onError', () => {
+    const onError = jest.fn()
+    jest.useFakeTimers()
+    renderErrorBoundary({
+      onError,
+      fallback: <>{FALLBACK}</>,
+      children: (
+        <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+          {TEXT}
+        </ThrowError>
+      ),
+    })
+    expect(container.textContent).toBe(TEXT)
+    expect(container.textContent).not.toBe(FALLBACK)
+    expect(onError).toHaveBeenCalledTimes(0)
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(container.textContent).toBe(FALLBACK)
+    expect(container.textContent).not.toBe(TEXT)
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('should show children if no error but if error in children, catch it and show fallback component', () => {
+    jest.useFakeTimers()
+    renderErrorBoundary({
+      fallback: (caught) => <>{caught.error.message}</>,
+      children: (
+        <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+          {TEXT}
+        </ThrowError>
+      ),
+    })
+    expect(container.textContent).toBe(TEXT)
+    expect(container.textContent).not.toBe(ERROR_MESSAGE)
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(container.textContent).toBe(ERROR_MESSAGE)
+    expect(container.textContent).not.toBe(TEXT)
+  })
+
+  it('should be reset by items of resetKeys, and call onReset', () => {
+    const onReset = jest.fn()
+    jest.useFakeTimers()
+    // reset by resetKeys[0]
+    renderErrorBoundary({
+      resetKeys: [0],
+      children: (
+        <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+          {TEXT}
+        </ThrowError>
+      ),
+      onReset,
+    })
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(container.textContent).toBe(ERROR_MESSAGE)
+    expect(container.textContent).not.toBe(TEXT)
+    expect(onReset).toHaveBeenCalledTimes(0)
+    renderErrorBoundary({
+      resetKeys: [1],
+      children: TEXT,
+      onReset,
+    })
+    expect(container.textContent).toBe(TEXT)
+    expect(onReset).toHaveBeenCalledTimes(1)
+
+    // reset by resetKeys.length
+    renderErrorBoundary({
+      resetKeys: [0],
+      children: (
+        <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+          {TEXT}
+        </ThrowError>
+      ),
+      onReset,
+    })
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(container.textContent).toBe(ERROR_MESSAGE)
+    expect(container.textContent).not.toBe(TEXT)
+
+    renderErrorBoundary({
+      resetKeys: [0, 1],
+      children: TEXT,
+      onReset,
+    })
+    expect(container.textContent).toBe(TEXT)
+    expect(onReset).toHaveBeenCalledTimes(2)
+  })
+
+  it('should be reset by ref.reset(), and call onReset', () => {
+    const onReset = jest.fn()
+    jest.useFakeTimers()
+    renderErrorBoundary({
+      children: (
+        <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+          {TEXT}
+        </ThrowError>
+      ),
+      onReset,
+    })
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(container.textContent).toBe(ERROR_MESSAGE)
+    expect(container.textContent).not.toBe(TEXT)
+    expect(onReset).toHaveBeenCalledTimes(0)
+
+    act(() => {
+      errorBoundaryRef.current?.reset()
+      ThrowError.reset()
+    })
+    renderErrorBoundary({
+      children: (
+        <ThrowError message={ERROR_MESSAGE} after={Infinity}>
+          {TEXT}
+        </ThrowError>
+      ),
+      onReset,
+    })
+    expect(container.textContent).toBe(TEXT)
+    expect(container.textContent).not.toBe(ERROR_MESSAGE)
+    expect(onReset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -114,8 +114,8 @@ class BaseErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
  */
 export const ErrorBoundary = forwardRef<{ reset(): void }, ComponentPropsWithoutRef<typeof BaseErrorBoundary>>(
   (props, resetRef) => {
-    const group = useContext(ErrorBoundaryGroupContext)
-    const resetKeys = group.resetKey ? [group.resetKey, ...(props.resetKeys || [])] : props.resetKeys
+    const group = useContext(ErrorBoundaryGroupContext) ?? { resetKey: 0 }
+    const resetKeys = [group.resetKey, ...(props.resetKeys || [])]
 
     const ref = useRef<BaseErrorBoundary>(null)
     useImperativeHandle(resetRef, () => ({

--- a/packages/react/src/ErrorBoundaryGroup.spec.tsx
+++ b/packages/react/src/ErrorBoundaryGroup.spec.tsx
@@ -1,0 +1,79 @@
+import { act, render, screen } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary'
+import { TEXT, MS_100, ThrowError, ERROR_MESSAGE } from './test-utils'
+import { ErrorBoundaryGroup, useErrorBoundaryGroup } from './ErrorBoundaryGroup'
+
+const innerErrorBoundaryCount = 3
+const resetButtonText = 'reset button'
+
+describe('ErrorBoundaryGroup', () => {
+  it('should reset all ErrorBoundaries in children', () => {
+    jest.useFakeTimers()
+    render(
+      <ErrorBoundaryGroup>
+        <ErrorBoundaryGroup.Reset trigger={(group) => <button onClick={group.reset}>{resetButtonText}</button>} />
+        {Array.from({ length: innerErrorBoundaryCount }).map((_, key) => (
+          <ErrorBoundary key={key} fallback={(caught) => <div>{caught.error.message}</div>}>
+            <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+              <div>{TEXT}</div>
+            </ThrowError>
+          </ErrorBoundary>
+        ))}
+      </ErrorBoundaryGroup>
+    )
+
+    expect(screen.getAllByText(TEXT).length).toBe(innerErrorBoundaryCount)
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(screen.getAllByText(ERROR_MESSAGE).length).toBe(innerErrorBoundaryCount)
+
+    const resetButton = screen.getByRole('button', { name: resetButtonText })
+    act(() => {
+      ThrowError.reset()
+      resetButton.click()
+    })
+    expect(screen.getAllByText(TEXT).length).toBe(innerErrorBoundaryCount)
+    expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument()
+  })
+
+  it('should reset all ErrorBoundaries in children even if it is nested, but if use blockOutside, can block reset by outside', () => {
+    jest.useFakeTimers()
+    render(
+      <ErrorBoundaryGroup>
+        <ErrorBoundaryGroup.Reset trigger={(group) => <button onClick={group.reset}>{resetButtonText}</button>} />
+        {Array.from({ length: innerErrorBoundaryCount }).map((_, index) => (
+          <ErrorBoundaryGroup key={index} blockOutside={index === innerErrorBoundaryCount - 1}>
+            <ErrorBoundary fallback={(caught) => <div>{caught.error.message}</div>}>
+              <ThrowError message={ERROR_MESSAGE} after={MS_100}>
+                <div>{TEXT}</div>
+              </ThrowError>
+            </ErrorBoundary>
+          </ErrorBoundaryGroup>
+        ))}
+      </ErrorBoundaryGroup>
+    )
+
+    expect(screen.getAllByText(TEXT).length).toBe(innerErrorBoundaryCount)
+    act(() => jest.advanceTimersByTime(MS_100))
+    expect(screen.getAllByText(ERROR_MESSAGE).length).toBe(innerErrorBoundaryCount)
+
+    const resetButton = screen.getByRole('button', { name: resetButtonText })
+    act(() => {
+      ThrowError.reset()
+      resetButton.click()
+    })
+    expect(screen.getAllByText(TEXT).length).toBe(innerErrorBoundaryCount - 1)
+    expect(screen.getAllByText(ERROR_MESSAGE).length).toBe(1)
+  })
+})
+
+describe('useErrorBoundaryGroup', () => {
+  it('should throw error without ErrorBoundaryGroup in parent', () => {
+    const WithoutErrorBoundaryGroup = () => {
+      useErrorBoundaryGroup()
+      return <></>
+    }
+    expect(() => render(<WithoutErrorBoundaryGroup />)).toThrow(
+      'useErrorBoundaryGroup: ErrorBoundaryGroup is required in parent'
+    )
+  })
+})

--- a/packages/react/src/ErrorBoundaryGroup.tsx
+++ b/packages/react/src/ErrorBoundaryGroup.tsx
@@ -3,7 +3,7 @@
 import { ComponentType, ReactNode, createContext, useContext, useEffect, useMemo } from 'react'
 import { useIsMounted, useKey } from './hooks'
 
-export const ErrorBoundaryGroupContext = createContext({ resetKey: 0, reset: () => {} })
+export const ErrorBoundaryGroupContext = createContext<{ reset: () => void; resetKey: number } | undefined>(undefined)
 if (process.env.NODE_ENV !== 'production') {
   ErrorBoundaryGroupContext.displayName = 'ErrorBoundaryGroupContext'
 }
@@ -35,7 +35,7 @@ export const ErrorBoundaryGroup = ({
     if (isMounted && !blockOutside) {
       reset()
     }
-  }, [group.resetKey, isMounted, reset])
+  }, [group?.resetKey, isMounted, reset])
 
   const value = useMemo(() => ({ reset, resetKey }), [reset, resetKey])
 
@@ -58,15 +58,19 @@ const ErrorBoundaryGroupReset = ({
 ErrorBoundaryGroup.Reset = ErrorBoundaryGroupReset
 
 export const useErrorBoundaryGroup = () => {
-  const { reset } = useContext(ErrorBoundaryGroupContext)
+  const group = useContext(ErrorBoundaryGroupContext)
+
+  if (group === undefined) {
+    throw new Error('useErrorBoundaryGroup: ErrorBoundaryGroup is required in parent')
+  }
 
   return useMemo(
     () => ({
       /**
        * When you want to reset multiple ErrorBoundaries as children of ErrorBoundaryGroup, You can use this reset
        */
-      reset,
+      reset: group.reset,
     }),
-    [reset]
+    [group.reset]
   )
 }

--- a/packages/react/src/test-utils/index.tsx
+++ b/packages/react/src/test-utils/index.tsx
@@ -1,19 +1,15 @@
-import { ReactNode } from 'react'
+import { PropsWithChildren, ReactNode, useEffect, useState } from 'react'
 
 const suspendIsNeed = { current: true }
-
-const suspend = (during: number) => {
-  throw new Promise((resolve) =>
-    setTimeout(() => {
-      suspendIsNeed.current = false
-      resolve('resolved')
-    }, during)
-  )
-}
-
-export const Suspend = ({ during = Infinity, toShow }: { during: number; toShow?: ReactNode }) => {
+type SuspendProps = { during: number; toShow?: ReactNode }
+export const Suspend = ({ during, toShow }: SuspendProps) => {
   if (suspendIsNeed.current) {
-    suspend(during)
+    throw new Promise((resolve) =>
+      setTimeout(() => {
+        suspendIsNeed.current = false
+        resolve('resolved')
+      }, during)
+    )
   }
   return <>{toShow}</>
 }
@@ -21,6 +17,23 @@ Suspend.reset = () => {
   suspendIsNeed.current = true
 }
 
+const throwErrorIsNeed = { current: false }
+type ThrowErrorProps = PropsWithChildren<{ message: string; after: number }>
+export const ThrowError = ({ message, after, children }: ThrowErrorProps) => {
+  const [isNeedError, setIsNeedError] = useState(throwErrorIsNeed.current)
+  if (isNeedError) {
+    throw new Error(message)
+  }
+  useEffect(() => {
+    setTimeout(() => setIsNeedError(true), after)
+  }, [after])
+  return <>{children}</>
+}
+ThrowError.reset = () => {
+  throwErrorIsNeed.current = false
+}
+
 export const TEXT = 'TEXT'
+export const ERROR_MESSAGE = 'ERROR_MESSAGE'
 export const FALLBACK = 'FALLBACK'
 export const MS_100 = 100

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,1 +1,1 @@
-export * from './hasResetKeysChanged'
+export { hasResetKeysChanged } from './hasResetKeysChanged'


### PR DESCRIPTION
# Fix useErrorBoundaryGroup to guarantee parent ErrorBoundaryGroup

<!--
    A clear and concise description of what this pr is about.
 -->

When we use useErrorBoundaryGroup, we could use it even though there is no ErrorBoundaryGroup as parent component. However, in the future it will throw an error in this case.

When this Pull Request is merged, I hope to avoid forgetting to use ErrorBoundaryGroup during development.

### I added test case more
- ErrorBoundaryGroup.spec.tsx
- ErrorBoundary.spec.tsx

## PR Checklist

- [x] I have written documents and tests, if needed.
