### PR TITLE
docs: reorder dependency managers for consistency

### DIFF
--- a/websites/docs/intro/installation.en.md
+++ b/websites/docs/intro/installation.en.md
@@ -16,7 +16,7 @@ npm install @suspensive/react
 Or if you're using <a href="https://pnpm.io/" target="_blank">pnpm</a>:
 
 ```shell
-pnpm install @suspensive/react
+pnpm add @suspensive/react
 ```
 
 ### yarn

--- a/websites/docs/intro/installation.en.md
+++ b/websites/docs/intro/installation.en.md
@@ -11,18 +11,18 @@ The Suspensive package lives in npm. To install the latest stable version, run t
 npm install @suspensive/react
 ```
 
-### yarn
-
-Or if you're using <a href="https://classic.yarnpkg.com/en/docs/install/" target="_blank">yarn</a>:
-
-```shell
-yarn add @suspensive/react
-```
-
 ### pnpm
 
 Or if you're using <a href="https://pnpm.io/" target="_blank">pnpm</a>:
 
 ```shell
 pnpm install @suspensive/react
+```
+
+### yarn
+
+Or if you're using <a href="https://classic.yarnpkg.com/en/docs/install/" target="_blank">yarn</a>:
+
+```shell
+yarn add @suspensive/react
 ```

--- a/websites/docs/intro/installation.ko.md
+++ b/websites/docs/intro/installation.ko.md
@@ -16,7 +16,7 @@ npm install @suspensive/react
 혹은 <a href="https://pnpm.io/" target="_blank">pnpm</a>을 사용한다면:
 
 ```shell
-pnpm install @suspensive/react
+pnpm add @suspensive/react
 ```
 
 ### yarn

--- a/websites/docs/intro/installation.ko.md
+++ b/websites/docs/intro/installation.ko.md
@@ -11,18 +11,18 @@ title: 설치하기
 npm install @suspensive/react
 ```
 
-### yarn
-
-혹은 <a href="https://classic.yarnpkg.com/en/docs/install/" target="_blank">yarn</a>을 사용한다면:
-
-```shell
-yarn add @suspensive/react
-```
-
 ### pnpm
 
 혹은 <a href="https://pnpm.io/" target="_blank">pnpm</a>을 사용한다면:
 
 ```shell
 pnpm install @suspensive/react
+```
+
+### yarn
+
+혹은 <a href="https://classic.yarnpkg.com/en/docs/install/" target="_blank">yarn</a>을 사용한다면:
+
+```shell
+yarn add @suspensive/react
 ```


### PR DESCRIPTION
# Overview

To ensure consistency across different sections of the documentation, the order of npm, yarn, and pnpm has been changed.

References:
- [React Section](https://suspensive.org/docs/react/README.i18n)
- [React Query Section](https://suspensive.org/docs/react-query/README.i18n)


<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I have written documents and tests, if needed.
