### PR TITLE
fix(react, react-query): remove unnecessary files by package.json's files

### DIFF
--- a/.changeset/tiny-swans-work.md
+++ b/.changeset/tiny-swans-work.md
@@ -1,0 +1,6 @@
+---
+"@suspensive/react-query": patch
+"@suspensive/react": patch
+---
+
+fix(react, react-query): remove unnecessary files by package.json's files

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -25,6 +25,12 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "!**/*/__test__",
+    "!**/*/_category_.json"
+  ],
   "scripts": {
     "build": "tsup",
     "lint": "eslint \"**/*.ts*\"",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,12 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "!**/*/__test__",
+    "!**/*/_category_.json"
+  ],
   "scripts": {
     "build": "tsup",
     "lint": "eslint \"**/*.ts*\"",


### PR DESCRIPTION
# Remove unnecessary files by package.json's files

<!--
    A clear and concise description of what this pr is about.
 -->

This change make our packages not to have unnecessary files(ex. __test__, _category_.json, jest.config.js, jest.setup.js, tsup.config.ts, etc.) on pack time (when we use `pnpm pack` command)

## PR Checklist

- [x] I have written documents and tests, if needed.
