### PR TITLE
fix(typescript): update version from v4 to v5

### DIFF
--- a/.changeset/green-bobcats-flash.md
+++ b/.changeset/green-bobcats-flash.md
@@ -1,0 +1,6 @@
+---
+"@suspensive/react-query": patch
+"@suspensive/react": patch
+---
+
+fix(typescript): update version from v4 to v5

--- a/configs/tsup/package.json
+++ b/configs/tsup/package.json
@@ -14,8 +14,7 @@
     "@suspensive/eslint-config-ts": "workspace:*",
     "@suspensive/tsconfig": "workspace:*",
     "eslint": "^8.42.0",
-    "tsup": "^7.1.0",
-    "typescript": "^4.9.5"
+    "tsup": "^7.1.0"
   },
   "peerDependencies": {
     "tsup": "^7"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "packlint": "^0.2.4",
     "prettier": "^2.8.8",
     "turbo": "latest",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.6"
   }
 }

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -62,8 +62,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsd": "^0.28.1",
-    "tsup": "^7.1.0",
-    "typescript": "^4.9.5"
+    "tsup": "^7.1.0"
   },
   "peerDependencies": {
     "@suspensive/react": "^1.11.4-beta.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,8 +58,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tsup": "^7.1.0",
-    "typescript": "^4.9.5"
+    "tsup": "^7.1.0"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17 || ^18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: latest
         version: 1.10.6
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.1.6
+        version: 5.1.6
 
   configs/babel:
     dependencies:
@@ -92,7 +92,7 @@ importers:
         version: 2.25.3(@typescript-eslint/parser@5.59.7)(eslint-import-resolver-typescript@2.5.0)(eslint@8.42.0)
       eslint-plugin-jest:
         specifier: ^27.2.1
-        version: 27.2.1(eslint@8.42.0)(typescript@4.9.5)
+        version: 27.2.1(eslint@8.42.0)(typescript@5.1.6)
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.3.0)(eslint@8.42.0)(prettier@2.8.8)
@@ -108,10 +108,10 @@ importers:
         version: link:../eslint-config-js
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.7.0
-        version: 5.7.0(@typescript-eslint/parser@5.59.7)(eslint@8.42.0)(typescript@4.9.5)
+        version: 5.7.0(@typescript-eslint/parser@5.59.7)(eslint@8.42.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.7.0
-        version: 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+        version: 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.3.0(eslint@8.42.0)
@@ -156,10 +156,7 @@ importers:
         version: 8.42.0
       tsup:
         specifier: ^7.1.0
-        version: 7.1.0(ts-node@10.9.1)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        version: 7.1.0(ts-node@10.9.1)(typescript@5.1.6)
 
   packages/react:
     devDependencies:
@@ -219,10 +216,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tsup:
         specifier: ^7.1.0
-        version: 7.1.0(ts-node@10.9.1)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        version: 7.1.0(ts-node@10.9.1)(typescript@5.1.6)
 
   packages/react-query:
     devDependencies:
@@ -291,19 +285,16 @@ importers:
         version: 0.28.1
       tsup:
         specifier: ^7.1.0
-        version: 7.1.0(ts-node@10.9.1)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        version: 7.1.0(ts-node@10.9.1)(typescript@5.1.6)
 
   websites/docs:
     dependencies:
       '@docusaurus/core':
         specifier: 2.4.1
-        version: 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+        version: 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/preset-classic':
         specifier: 2.4.1
-        version: 2.4.1(@algolia/client-search@4.18.0)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+        version: 2.4.1(@algolia/client-search@4.18.0)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@mdx-js/react':
         specifier: ^1.6.22
         version: 1.6.22(react@17.0.2)
@@ -325,7 +316,7 @@ importers:
         version: 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/theme-classic':
         specifier: ^2.4.1
-        version: 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+        version: 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/types':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@17.0.2)(react@17.0.2)
@@ -358,7 +349,7 @@ importers:
         version: 11.1.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.16.2)(typescript@4.9.5)
+        version: 10.9.1(@types/node@18.16.2)(typescript@5.1.6)
       utility-types:
         specifier: ^3.10.0
         version: 3.10.0
@@ -425,10 +416,7 @@ importers:
         version: 8.42.0
       eslint-config-next:
         specifier: ^13.4.4
-        version: 13.4.4(eslint@8.42.0)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        version: 13.4.4(eslint@8.42.0)(typescript@5.1.6)
 
 packages:
 
@@ -2116,13 +2104,13 @@ packages:
       '@types/node': 18.16.2
       chalk: 4.1.2
       cosmiconfig: 8.1.3
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.16.2)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@4.9.5)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.16.2)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.1.6)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@18.16.2)(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-node: 10.9.1(@types/node@18.16.2)(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -2234,7 +2222,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core@2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/core@2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -2293,7 +2281,7 @@ packages:
       postcss-loader: 7.3.2(postcss@8.4.24)(webpack@5.84.1)
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1(eslint@8.42.0)(typescript@4.9.5)(webpack@5.84.1)
+      react-dev-utils: 12.0.1(eslint@8.42.0)(typescript@5.1.6)(webpack@5.84.1)
       react-dom: 17.0.2(react@17.0.2)
       react-helmet-async: 1.3.0(react-dom@17.0.2)(react@17.0.2)
       react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.2)
@@ -2405,14 +2393,14 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/plugin-content-blog@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-content-blog@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/logger': 2.4.1
       '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
@@ -2447,14 +2435,14 @@ packages:
       - vue-template-compiler
       - webpack-cli
 
-  /@docusaurus/plugin-content-docs@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-content-docs@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/logger': 2.4.1
       '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/module-type-aliases': 2.4.1(react-dom@17.0.2)(react@17.0.2)
@@ -2489,14 +2477,14 @@ packages:
       - vue-template-compiler
       - webpack-cli
 
-  /@docusaurus/plugin-content-pages@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-content-pages@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
@@ -2523,14 +2511,14 @@ packages:
       - vue-template-compiler
       - webpack-cli
 
-  /@docusaurus/plugin-debug@2.4.1(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-debug@2.4.1(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-7Yu9UPzRShlrH/G8btOpR0e6INFZr0EegWplMjOqelIwAcx3PKyR8mgPTxGTxcqiYj6hxSCRN0D8R7YrzImwNA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       fs-extra: 10.1.0
@@ -2558,14 +2546,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-google-analytics@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
@@ -2589,14 +2577,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-google-gtag@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
@@ -2620,14 +2608,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-tag-manager@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-google-tag-manager@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-Zg4Ii9CMOLfpeV2nG74lVTWNtisFaH9QNtEw48R5QE1KIwDBdTVaiSA18G1EujZjrzJJzXN79VhINSbOJO/r3g==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       react: 17.0.2
@@ -2651,14 +2639,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/plugin-sitemap@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-lZx+ijt/+atQ3FVE8FOHV/+X3kuok688OydDXrqKRJyXBJZKgGjA2Qa8RjQ4f27V2woaXhtnyrdPop/+OjVMRg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/logger': 2.4.1
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
@@ -2687,25 +2675,25 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic@2.4.1(@algolia/client-search@4.18.0)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/preset-classic@2.4.1(@algolia/client-search@4.18.0)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-P4//+I4zDqQJ+UDgoFrjIFaQ1MeS9UD1cvxVQaI6O7iBmiHQm0MGROP1TbE7HlxlDPXFJjZUK3x3cAoK63smGQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-debug': 2.4.1(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-google-analytics': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-google-gtag': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-google-tag-manager': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-sitemap': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-classic': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-common': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-search-algolia': 2.4.1(@algolia/client-search@4.18.0)(@docusaurus/types@2.4.1)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-debug': 2.4.1(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-google-analytics': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-google-gtag': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-google-tag-manager': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-sitemap': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/theme-classic': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/theme-common': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/theme-search-algolia': 2.4.1(@algolia/client-search@4.18.0)(@docusaurus/types@2.4.1)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -2739,20 +2727,20 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /@docusaurus/theme-classic@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/theme-classic@2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-Rz0wKUa+LTW1PLXmwnf8mn85EBzaGSt6qamqtmnh9Hflkc+EqiYMhtUJeLdV+wsgYq4aG0ANc+bpUDpsUhdnwg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/module-type-aliases': 2.4.1(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-common': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/theme-common': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/theme-translations': 2.4.1
       '@docusaurus/types': 2.4.1(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
@@ -2790,7 +2778,7 @@ packages:
       - vue-template-compiler
       - webpack-cli
 
-  /@docusaurus/theme-common@2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/theme-common@2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -2799,9 +2787,9 @@ packages:
     dependencies:
       '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/module-type-aliases': 2.4.1(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       '@docusaurus/utils-common': 2.4.1(@docusaurus/types@2.4.1)
       '@types/history': 4.7.11
@@ -2833,7 +2821,7 @@ packages:
       - vue-template-compiler
       - webpack-cli
 
-  /@docusaurus/theme-search-algolia@2.4.1(@algolia/client-search@4.18.0)(@docusaurus/types@2.4.1)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/theme-search-algolia@2.4.1(@algolia/client-search@4.18.0)(@docusaurus/types@2.4.1)(@types/react@18.2.0)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-6BcqW2lnLhZCXuMAvPRezFs1DpmEKzXFKlYjruuas+Xy3AQeFzDJKTJFIm49N77WFCTyxff8d3E4Q9pi/+5McQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -2841,10 +2829,10 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@docsearch/react': 3.4.0(@algolia/client-search@4.18.0)(@types/react@18.2.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/logger': 2.4.1
-      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-common': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
+      '@docusaurus/theme-common': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.42.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
       '@docusaurus/theme-translations': 2.4.1
       '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
@@ -4485,7 +4473,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  /@typescript-eslint/eslint-plugin@5.7.0(@typescript-eslint/parser@5.59.7)(eslint@8.42.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.7.0(@typescript-eslint/parser@5.59.7)(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4496,8 +4484,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.7.0(eslint@8.42.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/experimental-utils': 5.7.0(eslint@8.42.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.7.0
       debug: 4.3.4
       eslint: 8.42.0
@@ -4505,13 +4493,13 @@ packages:
       ignore: 5.2.4
       regexpp: 3.2.0
       semver: 7.5.1
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils@5.7.0(eslint@8.42.0)(typescript@4.9.5):
+  /@typescript-eslint/experimental-utils@5.7.0(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4520,7 +4508,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 5.7.0
       '@typescript-eslint/types': 5.7.0
-      '@typescript-eslint/typescript-estree': 5.7.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.7.0(typescript@5.1.6)
       eslint: 8.42.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.42.0)
@@ -4529,7 +4517,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser@5.59.7(eslint@8.42.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.59.7(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-VhpsIEuq/8i5SF+mPg9jSdIwgMBBp0z9XqjiEay+81PYLJuroN+ET1hM5IhkiYMJd9MkTz8iJLt7aaGAgzWUbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4541,10 +4529,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.7
       '@typescript-eslint/types': 5.59.7
-      '@typescript-eslint/typescript-estree': 5.59.7(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.59.7(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.42.0
-      typescript: 4.9.5
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
@@ -4572,7 +4560,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.59.7(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.59.7(typescript@5.1.6):
     resolution: {integrity: sha512-4A1NtZ1I3wMN2UGDkU9HMBL+TIQfbrh4uS0WDMMpf3xMRursDbqEf1ahh6vAAe3mObt8k3ZATnezwG4pdtWuUQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4587,12 +4575,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.1
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.7.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.7.0(typescript@5.1.6):
     resolution: {integrity: sha512-aO1Ql+izMrTnPj5aFFlEJkpD4jRqC4Gwhygu2oHK2wfVQpmOPbyDSveJ+r/NQo+PWV43M6uEAeLVbTi09dFLhg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4607,13 +4595,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.1
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.59.7(eslint@8.42.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.59.7(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-yCX9WpdQKaLufz5luG4aJbOpdXf/fjwGMcLFXZVPUz3QqLirG5QcwwnIHNf8cjLjxK4qtzTO8udUtMQSAToQnQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4624,7 +4612,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.7
       '@typescript-eslint/types': 5.59.7
-      '@typescript-eslint/typescript-estree': 5.59.7(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.59.7(typescript@5.1.6)
       eslint: 8.42.0
       eslint-scope: 5.1.1
       semver: 7.5.1
@@ -6064,7 +6052,7 @@ packages:
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader@4.3.0(@types/node@18.16.2)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@4.9.5):
+  /cosmiconfig-typescript-loader@4.3.0(@types/node@18.16.2)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.1.6):
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -6075,8 +6063,8 @@ packages:
     dependencies:
       '@types/node': 18.16.2
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@18.16.2)(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-node: 10.9.1(@types/node@18.16.2)(typescript@5.1.6)
+      typescript: 5.1.6
     dev: true
 
   /cosmiconfig@6.0.0:
@@ -6994,7 +6982,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@13.4.4(eslint@8.42.0)(typescript@4.9.5):
+  /eslint-config-next@13.4.4(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-z/PMbm6L0iC/fwISULxe8IVy4DtNqZk2wQY711o35klenq70O6ns82A8yuMVCFjHC0DIyB2lyugesRtuk9u8dQ==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -7005,7 +6993,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.4.4
       '@rushstack/eslint-patch': 1.3.0
-      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.7)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.42.0)
@@ -7013,7 +7001,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.42.0)
       eslint-plugin-react: 7.32.2(eslint@8.42.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.42.0)
-      typescript: 4.9.5
+      typescript: 5.1.6
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -7114,7 +7102,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       debug: 3.2.7
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
@@ -7144,7 +7132,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       debug: 3.2.7
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
@@ -7163,7 +7151,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
@@ -7194,7 +7182,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -7217,7 +7205,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@27.2.1(eslint@8.42.0)(typescript@4.9.5):
+  /eslint-plugin-jest@27.2.1(eslint@8.42.0)(typescript@5.1.6):
     resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -7230,7 +7218,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.59.7(eslint@8.42.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.59.7(eslint@8.42.0)(typescript@5.1.6)
       eslint: 8.42.0
     transitivePeerDependencies:
       - supports-color
@@ -7790,7 +7778,7 @@ packages:
     dependencies:
       is-callable: 1.2.7
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.42.0)(typescript@4.9.5)(webpack@5.84.1):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.42.0)(typescript@5.1.6)(webpack@5.84.1):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -7818,7 +7806,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.5.1
       tapable: 1.1.3
-      typescript: 4.9.5
+      typescript: 5.1.6
       webpack: 5.84.1
 
   /form-data@4.0.0:
@@ -9283,7 +9271,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.16.2)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@18.16.2)(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9323,7 +9311,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.16.2)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@18.16.2)(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -11477,7 +11465,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      ts-node: 10.9.1(@types/node@18.16.2)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@18.16.2)(typescript@5.1.6)
       yaml: 2.3.1
     dev: true
 
@@ -12013,7 +12001,7 @@ packages:
       pure-color: 1.3.0
     dev: false
 
-  /react-dev-utils@12.0.1(eslint@8.42.0)(typescript@4.9.5)(webpack@5.84.1):
+  /react-dev-utils@12.0.1(eslint@8.42.0)(typescript@5.1.6)(webpack@5.84.1):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -12032,7 +12020,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.42.0)(typescript@4.9.5)(webpack@5.84.1)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.42.0)(typescript@5.1.6)(webpack@5.84.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -12047,7 +12035,7 @@ packages:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 4.9.5
+      typescript: 5.1.6
       webpack: 5.84.1
     transitivePeerDependencies:
       - eslint
@@ -13564,7 +13552,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.16.2)(typescript@4.9.5):
+  /ts-node@10.9.1(@types/node@18.16.2)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -13590,7 +13578,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -13626,7 +13614,7 @@ packages:
   /tslib@2.5.2:
     resolution: {integrity: sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==}
 
-  /tsup@7.1.0(ts-node@10.9.1)(typescript@4.9.5):
+  /tsup@7.1.0(ts-node@10.9.1)(typescript@5.1.6):
     resolution: {integrity: sha512-mazl/GRAk70j8S43/AbSYXGgvRP54oQeX8Un4iZxzATHt0roW0t6HYDVZIXMw0ZQIpvr1nFMniIVnN5186lW7w==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -13656,20 +13644,20 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 4.9.5
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils@3.21.0(typescript@4.9.5):
+  /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.1.6
 
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}
@@ -13818,9 +13806,9 @@ packages:
     dependencies:
       is-typedarray: 1.0.0
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /ua-parser-js@0.7.35:

--- a/websites/visualization/package.json
+++ b/websites/visualization/package.json
@@ -31,7 +31,6 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
     "eslint": "^8.42.0",
-    "eslint-config-next": "^13.4.4",
-    "typescript": "^4.9.5"
+    "eslint-config-next": "^13.4.4"
   }
 }


### PR DESCRIPTION
close #33 

# Update TypeScript version from v4 to v5 
- I updated version of TypeScript
- I remained TypeScript only in root. and I removed it in all packages

## PR Checklist

- [x] I have written documents and tests, if needed.
