### PR TITLE
refactor(react): apply assert

### DIFF
--- a/.changeset/long-donkeys-applaud.md
+++ b/.changeset/long-donkeys-applaud.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+refactor(react): apply assert

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["."],
   "exclude": ["**/*.test-d.ts", "**/*.test-d.tsx"],
   "compilerOptions": {
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom"]
   }
 }

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["."],
   "exclude": ["**/*.test-d.ts", "**/*.test-d.tsx"],
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["node", "@testing-library/jest-dom"]
   }
 }

--- a/packages/react/src/AsyncBoundary.spec.tsx
+++ b/packages/react/src/AsyncBoundary.spec.tsx
@@ -1,6 +1,7 @@
 import { act, render, waitFor } from '@testing-library/react'
 import { ComponentProps, createElement } from 'react'
 import { createRoot } from 'react-dom/client'
+import { vi } from 'vitest'
 import { ERROR_MESSAGE, FALLBACK, MS_100, Suspend, TEXT, ThrowError } from './utils/toTest'
 import { AsyncBoundary, withAsyncBoundary } from '.'
 

--- a/packages/react/src/Delay.spec.tsx
+++ b/packages/react/src/Delay.spec.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
 import { MS_100, TEXT } from './utils/toTest'
 import { Delay, withDelay } from '.'
 

--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -1,6 +1,7 @@
 import { act } from '@testing-library/react'
 import { ComponentProps, ComponentRef, createRef } from 'react'
 import { createRoot } from 'react-dom/client'
+import { vi } from 'vitest'
 import { ERROR_MESSAGE, FALLBACK, MS_100, TEXT, ThrowError, ThrowNull } from './utils/toTest'
 import { ErrorBoundary } from '.'
 

--- a/packages/react/src/ErrorBoundaryGroup.spec.tsx
+++ b/packages/react/src/ErrorBoundaryGroup.spec.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from '@testing-library/react'
 import { createElement } from 'react'
+import { vi } from 'vitest'
 import { ERROR_MESSAGE, MS_100, TEXT, ThrowError } from './utils/toTest'
 import { ErrorBoundary, ErrorBoundaryGroup, useErrorBoundaryGroup, withErrorBoundaryGroup } from '.'
 

--- a/packages/react/src/ErrorBoundaryGroup.tsx
+++ b/packages/react/src/ErrorBoundaryGroup.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps, ComponentType, PropsWithChildren, createContext, useContext, useEffect, useMemo } from 'react'
 import { useIsChanged, useKey } from './hooks'
 import { PropsWithoutChildren } from './types'
+import { assert } from './utils'
 
 export const ErrorBoundaryGroupContext = createContext<{ reset: () => void; resetKey: number } | undefined>(undefined)
 if (process.env.NODE_ENV !== 'production') {
@@ -53,11 +54,7 @@ ErrorBoundaryGroup.Reset = ErrorBoundaryGroupReset
 
 export const useErrorBoundaryGroup = () => {
   const group = useContext(ErrorBoundaryGroupContext)
-
-  if (group === undefined) {
-    throw new Error('useErrorBoundaryGroup: ErrorBoundaryGroup is required in parent')
-  }
-
+  assert(group != null, 'useErrorBoundaryGroup: ErrorBoundaryGroup is required in parent')
   return useMemo(
     () => ({
       /**

--- a/packages/react/src/Suspense.spec.tsx
+++ b/packages/react/src/Suspense.spec.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
+import { vi } from 'vitest'
 import { FALLBACK, MS_100, Suspend, TEXT } from './utils/toTest'
 import { Suspense, withSuspense } from '.'
 

--- a/packages/react/src/SuspensiveProvider.spec.tsx
+++ b/packages/react/src/SuspensiveProvider.spec.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
 import { FALLBACK, MS_100, Suspend, TEXT } from './utils/toTest'
 import { Delay, Suspense, Suspensive, SuspensiveProvider } from '.'
 

--- a/packages/react/src/experimental/Await.spec.tsx
+++ b/packages/react/src/experimental/Await.spec.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
 import { ErrorBoundary, Suspense } from '..'
 import { ERROR_MESSAGE, FALLBACK, MS_100, TEXT, delay } from '../utils/toTest'
 import { awaitClient, useAwait } from '.'

--- a/packages/react/src/utils/assert.spec.ts
+++ b/packages/react/src/utils/assert.spec.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf } from 'vitest'
 import { assert } from '.'
 
 function get(type: 'foo' | 'bar') {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "@suspensive/tsconfig/react-library.json",
   "include": ["."],
   "compilerOptions": {
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom"]
   }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "@suspensive/tsconfig/react-library.json",
   "include": ["."],
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["node", "@testing-library/jest-dom"]
   }
 }


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I applied assert in use case

I removed "vitest/globals" in tsconfig to prevent contributors use `assert of chai used by vitest's global.d.ts` instead of our `assert in src/utils` So I want to force contributor write where assert import from.

### What situation I want to prevent
No error when using `assert of chai used by vitest's global.d.ts` in ErrorBoundaryGroup.tsx, not *.spec.tsx

![image](https://github.com/suspensive/react/assets/61593290/f6e1eb06-61e6-4474-91d7-0ce08456a62b)



## PR Checklist

- [x] I have written documents and tests, if needed.
