### PR TITLE
test(react): add tests for withErrorBoundary

### DIFF
--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -167,7 +167,7 @@ describe('withErrorBoundary', () => {
     ThrowError.reset()
   })
 
-  it('should render the wrapped component when there`s no error', () => {
+  it("should render the wrapped component when there's no error", () => {
     const WrappedComponent = withErrorBoundary(() => <>{TEXT}</>, {
       fallback: (caught) => <>{caught.error.message}</>,
     })


### PR DESCRIPTION
related with #62

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Introducing tests for the `withErrorBoundary` ensures that is working as expected and provides the necessary error boundaries for the components it wraps. The `withErrorBoundary` is designed to catch rendering errors in its child component and display a **fallback UI** instead of crashing the entire app.

AS-IS
<img width="588" alt="스크린샷 2023-09-23 오후 10 05 20" src="https://github.com/suspensive/react/assets/77133565/5200118e-28ca-4f29-a5dc-10ce07e882cc">


TO-BE
<img width="618" alt="스크린샷 2023-09-23 오후 10 05 32" src="https://github.com/suspensive/react/assets/77133565/cb890373-ca56-4906-98b9-003417314901">


## PR Checklist

- [x] I have written documents and tests, if needed.
