### PR TITLE
test(react): add additional displayName test cases for withErrorBoundaryGroup

### DIFF
--- a/packages/react/src/ErrorBoundaryGroup.spec.tsx
+++ b/packages/react/src/ErrorBoundaryGroup.spec.tsx
@@ -84,4 +84,15 @@ describe('withErrorBoundaryGroup', () => {
     const rendered = render(createElement(withErrorBoundaryGroup(UsingUseErrorBoundary)))
     expect(rendered.queryByText(TEXT)).toBeInTheDocument()
   })
+
+  it('should set displayName based on Component.displayName', () => {
+    const TestComponentWithDisplayName = () => <>{TEXT}</>
+    TestComponentWithDisplayName.displayName = 'TestDisplayName'
+
+    expect(withErrorBoundaryGroup(TestComponentWithDisplayName).displayName).toBe(
+      'withErrorBoundaryGroup(TestDisplayName)'
+    )
+
+    expect(withErrorBoundaryGroup(() => <>{TEXT}</>).displayName).toBe('withErrorBoundaryGroup(Component)')
+  })
 })


### PR DESCRIPTION
related with #62

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

- Add new test scenarios to cover displayName determination in `withErrorBoundaryGroup`
- Address uncovered lines related to displayName handling
- Ensure comprehensive test coverage

AS-IS
<img width="612" alt="스크린샷 2023-09-23 오후 10 49 54" src="https://github.com/suspensive/react/assets/77133565/0706f183-b628-4c1d-adde-78d77199afb2">


TO-BE
<img width="616" alt="스크린샷 2023-09-23 오후 10 49 25" src="https://github.com/suspensive/react/assets/77133565/d4833b03-01e9-4e81-803d-52d40053304e">

## PR Checklist

- [x] I have written documents and tests, if needed.
