### PR TITLE
test(react): add Await, AwaitClient's clearError case

### DIFF
--- a/packages/react/src/experimental/Await.spec.tsx
+++ b/packages/react/src/experimental/Await.spec.tsx
@@ -2,7 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import { ErrorBoundary, Suspense } from '..'
 import { ERROR_MESSAGE, FALLBACK, MS_100, TEXT, delay } from '../utils/toTest'
-import { awaitClient, useAwait } from '.'
+import { Await, awaitClient, useAwait } from '.'
 
 const key = ['key'] as const
 
@@ -94,5 +94,32 @@ describe('useAwait', () => {
     expect(screen.queryByText(FALLBACK)).toBeInTheDocument()
     act(() => vi.advanceTimersByTime(MS_100))
     await waitFor(() => expect(screen.queryByText(TEXT)).toBeInTheDocument())
+  })
+})
+
+describe('Await component', () => {
+  it('should render child component with data from useAwait hook', async () => {
+    render(
+      <Suspense fallback="Loading...">
+        <Await options={{ key, fn: () => Promise.resolve(TEXT) }}>{({ data }) => <>{data}</>}</Await>
+      </Suspense>
+    )
+
+    expect(await screen.findByText(TEXT)).toBeInTheDocument()
+  })
+})
+
+describe('class AwaitClient clearError', () => {
+  beforeEach(() => awaitClient.reset())
+
+  it('clears promise & error for all cache without key', async () => {
+    try {
+      await awaitClient.suspend({ key, fn: () => Promise.reject(new Error(ERROR_MESSAGE)) })
+    } catch {
+      // Expected an error
+    }
+
+    awaitClient.clearError()
+    expect(awaitClient.getData([key])).toBeUndefined()
   })
 })


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

- Updated the tests for the `Await` component to verify its behavior with the `useAwait` hook.
- Added tests for the `AwaitClient` class's `clearError` method to check its behavior after a failed suspend operation.

### AS-IS
<img width="575" alt="스크린샷 2023-09-24 오후 7 41 47" src="https://github.com/suspensive/react/assets/77133565/b48dd9dd-b83f-4d24-aa19-888d86a1a9f7">


### TO-BE
<img width="557" alt="스크린샷 2023-09-24 오후 7 41 25" src="https://github.com/suspensive/react/assets/77133565/fd2bb794-d39d-4749-93fc-7338a5b90557">

I haven't added tests for the parts where TODOs were left in the logic.

## PR Checklist

- [x] I have written documents and tests, if needed.
