### PR TITLE
docs: update experimental feature mark as admonitions of docusaurus

### DIFF
--- a/.changeset/ninety-yaks-flash.md
+++ b/.changeset/ninety-yaks-flash.md
@@ -2,4 +2,4 @@
 "@suspensive/react": patch
 ---
 
-docs: update experimental feature mark
+docs: update experimental feature mark as admonitions of docusaurus

--- a/.changeset/ninety-yaks-flash.md
+++ b/.changeset/ninety-yaks-flash.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+docs: update experimental feature mark

--- a/packages/react/src/ErrorBoundary.en.mdx
+++ b/packages/react/src/ErrorBoundary.en.mdx
@@ -100,7 +100,13 @@ const Example = (
 )
 ```
 
-## useErrorBoundary (experimental)
+## useErrorBoundary
+
+:::caution Experimental
+
+useErrorBoundary is experimental feature, this interfaces could be changed
+
+:::
 
 We can reset `<ErrorBoundary/>` without props using useErrorBoundary.reset in ErrorBoundaryFallback.
 

--- a/packages/react/src/ErrorBoundary.ko.mdx
+++ b/packages/react/src/ErrorBoundary.ko.mdx
@@ -100,7 +100,13 @@ const Example = (
 )
 ```
 
-## useErrorBoundary (experimental)
+## useErrorBoundary
+
+:::caution Experimental
+
+useErrorBoundary는 실험 기능이므로 이 인터페이스는 변경될 수 있습니다.
+
+:::
 
 ErrorBoundaryFallback에서 useErrorBoundary.reset을 사용해 props 없이도 `<ErrorBoundary/>`을 reset할 수 있습니다.
 

--- a/packages/react/src/experimental/Await.en.mdx
+++ b/packages/react/src/experimental/Await.en.mdx
@@ -3,7 +3,11 @@ sidebar_position: 7
 title: <Await/>
 ---
 
-> NOTE: Await of @supensive/react is experimental feature, this interfaces could be changed frequently
+:::caution Experimental
+
+`<Await/>` of @supensive/react is experimental feature, this interfaces could be changed
+
+:::
 
 This component exposes a fallback of the nearest parent Suspense if the Promise returned by the received asynchronous function is pending.
 Afterwards, when the Promise is fulfilled, the guaranteed awaited data can be used in children components.

--- a/packages/react/src/experimental/Await.ko.mdx
+++ b/packages/react/src/experimental/Await.ko.mdx
@@ -3,7 +3,11 @@ sidebar_position: 7
 title: <Await/>
 ---
 
-> 참고: @supensive/react의 Await는 experimental 기능이므로 이 인터페이스는 자주 변경될 수 있습니다.
+:::caution Experimental
+
+@supensive/react의 `<Await/>`는 실험 기능이므로 이 인터페이스는 변경될 수 있습니다.
+
+:::
 
 이 컴포넌트는 받은 비동기 함수가 리턴한 Promise가 pending이면 가장 가까운 부모 Suspense의 fallback을 노출합니다.
 이후 Promise가 fulfilled되면 children 컴포넌트들에서 보장된 awaited data를 사용할 수 있게 합니다.


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I updated experimental feature mark as [admonitions](https://docusaurus.io/docs/markdown-features/admonitions) of docusaurus

### AS-IS
![image](https://github.com/suspensive/react/assets/61593290/4dc2d54d-2f0b-43db-922a-4374a137faff)

### TO-BE
![image](https://github.com/suspensive/react/assets/61593290/2ac77dfc-f2b2-4762-8907-92e766a1feb0)

## PR Checklist

- [x] I have written documents and tests, if needed.
