### PR TITLE
fix: remove awaitClient from ErrorBoundary

### DIFF
--- a/.changeset/large-schools-destroy.md
+++ b/.changeset/large-schools-destroy.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix: remove awaitClient from ErrorBoundary

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -16,7 +16,6 @@ import {
   useState,
 } from 'react'
 import { ErrorBoundaryGroupContext } from './ErrorBoundaryGroup'
-import { awaitClient } from './experimental/Await'
 import { PropsWithoutChildren } from './types'
 import { hasResetKeysChanged } from './utils'
 import { assert } from './utils'
@@ -86,7 +85,6 @@ class BaseErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
 
   reset() {
     this.props.onReset?.()
-    awaitClient.clearError()
     this.setState(initialState)
   }
 


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

https://github.com/suspensive/react/pull/203#issuecomment-1745714118

## PR Checklist

- [x] I have written documents and tests, if needed.
