### PR TITLE
chore(pnpm): force corepack by preinstall

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ In general, things we find useful when reviewing suggestions are:
     ```shell
     git clone git@github.com:suspensive/react.git
     ```
-2. Install relative packages. [We use pnpm v8. Install it please if need](https://pnpm.io/installation)
+2. Please use the correct node version. You can use the version declared in [.nvmrc](https://github.com/suspensive/react/blob/main/.nvmrc). We strongly recommend [nvm](https://github.com/nvm-sh/nvm) to control local machine's node version easily. also We recommend [nvm's deeper shell integration](https://github.com/nvm-sh/nvm#deeper-shell-integration) too.
+3. Install packages. [We use pnpm v8. Install pnpm with corepack please if you can](https://pnpm.io/installation#using-corepack). We recommend using corepack for pnpm to automatically use the version declared in the packageManager field of package.json.
     ```shell
     pnpm install
     ```

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint:pack": "packlint sort -R",
     "lint:pub": "turbo run lint:pub",
     "postinstall": "husky install",
+    "preinstall": "corepack enable",
     "prepack": "turbo run prepack",
     "test": "turbo run test",
     "test:tsd": "turbo run test:tsd",


### PR DESCRIPTION
fix #243 

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

If we force [corepack, we don't need to notice what version we need to use for pnpm](https://pnpm.io/installation#using-corepack).
So I use preinstall of package.json and update CONTRIBUTING.md

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
