### PR TITLE
fix: add module field of package.json

### DIFF
--- a/.changeset/smooth-poets-glow.md
+++ b/.changeset/smooth-poets-glow.md
@@ -1,0 +1,7 @@
+---
+"@suspensive/react-await": patch
+"@suspensive/react-query": patch
+"@suspensive/react": patch
+---
+
+fix: add module field of package.json

--- a/packages/react-await/package.json
+++ b/packages/react-await/package.json
@@ -38,6 +38,7 @@
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -39,6 +39,7 @@
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,6 +38,7 @@
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
fix #271 

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I added module field of package.json to define esm's entry

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
