### PR TITLE
fix(react): remove useless variable assigning in useIsomorphicLayoutEffect

### DIFF
--- a/.changeset/healthy-zoos-matter.md
+++ b/.changeset/healthy-zoos-matter.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix(react): remove useless variable assigning in useIsomorphicLayoutEffect

--- a/configs/test-utils/src/ThrowError.tsx
+++ b/configs/test-utils/src/ThrowError.tsx
@@ -1,8 +1,7 @@
 import type { PropsWithChildren } from 'react'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
-const isClient = typeof window !== 'undefined'
-export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 export const useTimeout = (fn: () => void, ms: number) => {
   const fnRef = useRef(fn)

--- a/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,3 @@
 import { useEffect, useLayoutEffect } from 'react'
-
-export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
+const isClient = typeof window !== 'undefined'
+export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect

--- a/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,3 @@
 import { useEffect, useLayoutEffect } from 'react'
-const isClient = typeof window !== 'undefined'
-export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect
+
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect

--- a/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,2 @@
 import { useEffect, useLayoutEffect } from 'react'
-const isClient = typeof window !== 'undefined'
-export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect


### PR DESCRIPTION
fix #281 

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I remove isClient in `useIsomorphicLayoutEffect`

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
