### PR TITLE
fix(tsup): add splitting to reduce bundle size dramatically

### DIFF
--- a/.changeset/smooth-birds-sip.md
+++ b/.changeset/smooth-birds-sip.md
@@ -1,5 +1,8 @@
 ---
-"@suspensive/tsup": patch
+"@suspensive/react": patch
+"@suspensive/react-query": patch
+"@suspensive/react-await": patch
+"@suspensive/react-image": patch
 ---
 
 fix(tsup): add splitting to reduce bundle size dramatically

--- a/.changeset/smooth-birds-sip.md
+++ b/.changeset/smooth-birds-sip.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/tsup": patch
+---
+
+fix(tsup): add splitting to reduce bundle size dramatically

--- a/configs/tsup/src/index.ts
+++ b/configs/tsup/src/index.ts
@@ -7,5 +7,4 @@ export const options: Options = {
   entry: ['src/*.{ts,tsx}', '!**/*.{spec,test,test-d}.*'],
   sourcemap: true,
   dts: true,
-  splitting: false,
 }


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

add splitting to reduce bundle size dramatically for esm

### How size bundle reduced

#### AS-IS (721KB)
![Screenshot 2023-12-12 at 8 52 26 PM](https://github.com/suspensive/react/assets/61593290/0ee3dd7c-dd92-448a-be27-41f74ee111dc)

#### TO-BE (407KB)
![Screenshot 2023-12-12 at 8 53 09 PM](https://github.com/suspensive/react/assets/61593290/9ef11d68-7c32-42bc-948f-94d6bd581cde)

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
