### PR TITLE
feat(react): add Suspense clientOnly prop to deprecate Suspense.CSROnly, wrap.Suspense.CSROnly

### DIFF
--- a/.changeset/three-seahorses-peel.md
+++ b/.changeset/three-seahorses-peel.md
@@ -1,0 +1,6 @@
+---
+"@suspensive/react-query": patch
+"@suspensive/react": patch
+---
+
+feat(react): add Suspense clientOnly prop to deprecate Suspense.CSROnly, wrap.Suspense.CSROnly

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All declarative components to use suspense on both CSR, SSR.
 - ErrorBoundaryGroup, useErrorBoundaryGroup
 - Delay
 - SuspensiveProvider, Suspensive
+- DevMode
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All declarative components to use suspense on both CSR, SSR.
 
 ### Features
 
-- Suspense Suspense.CSROnly
+- Suspense
 - ErrorBoundary, useErrorBoundary, useErrorBoundaryFallbackProps
 - ErrorBoundaryGroup, useErrorBoundaryGroup
 - Delay

--- a/configs/tsup/src/index.ts
+++ b/configs/tsup/src/index.ts
@@ -9,5 +9,4 @@ export const options: Options = {
   dts: true,
   minify: true,
   treeshake: true,
-  clean: true,
 }

--- a/docs/v1/src/pages/docs/react/AsyncBoundary.en.mdx
+++ b/docs/v1/src/pages/docs/react/AsyncBoundary.en.mdx
@@ -50,7 +50,7 @@ type AsyncBoundaryProps = Omit<SuspenseProps, 'fallback'> &
 
 <Callout type='warning'>
 
-deprecated: Use [wrap.ErrorBoundary().Suspense().on](./wrap), [wrap.ErrorBoundary().Suspense.CSROnly().on](./wrap) instead
+deprecated: Use [wrap.ErrorBoundary().Suspense().on](./wrap) instead
 
 </Callout>
 

--- a/docs/v1/src/pages/docs/react/AsyncBoundary.en.mdx
+++ b/docs/v1/src/pages/docs/react/AsyncBoundary.en.mdx
@@ -46,36 +46,6 @@ type AsyncBoundaryProps = Omit<SuspenseProps, 'fallback'> &
   }
 ```
 
-### Avoid Server side rendering (CSROnly)
-
-<Callout type='warning'>
-
-deprecated: Use `<Suspense.CSROnly/>` and `<ErrorBoundary/>` directly
-
-</Callout>
-
-Since it wraps `<Suspense.CSROnly/>`, it provides the same CSROnly.
-
-```tsx /AsyncBoundary.CSROnly/
-import { AsyncBoundary } from '@suspensive/react'
-
-const Example = () => (
-  <AsyncBoundary.CSROnly
-    pendingFallback={<Loading />}
-    rejectedFallback={(props) => (
-      <>
-        <button onClick={props.reset}>Try again</button>
-        {props.error.message}
-      </>
-    )}
-    onReset={() => console.log('reset')}
-    onError={(error) => console.log(error)}
-  >
-    <Children />
-  </AsyncBoundary.CSROnly>
-)
-```
-
 ## withAsyncBoundary
 
 <Callout type='warning'>

--- a/docs/v1/src/pages/docs/react/AsyncBoundary.ko.mdx
+++ b/docs/v1/src/pages/docs/react/AsyncBoundary.ko.mdx
@@ -48,36 +48,6 @@ type AsyncBoundaryProps = Omit<SuspenseProps, 'fallback'> &
   }
 ```
 
-### 서버사이드 렌더링을 피하기 (CSROnly)
-
-<Callout type='warning'>
-
-deprecated: `<Suspense.CSROnly/>`와 `<ErrorBoundary/>`를 직접 사용하세요
-
-</Callout>
-
-`<Suspense.CSROnly/>`를 래핑하기 때문에 동일하게 CSROnly를 제공합니다.
-
-```tsx /AsyncBoundary.CSROnly/
-import { AsyncBoundary } from '@suspensive/react'
-
-const Example = () => (
-  <AsyncBoundary.CSROnly
-    pendingFallback={<Loading />}
-    rejectedFallback={(props) => (
-      <>
-        <button onClick={props.reset}>Try again</button>
-        {props.error.message}
-      </>
-    )}
-    onReset={() => console.log('reset')}
-    onError={(error) => console.log(error)}
-  >
-    <Children />
-  </AsyncBoundary.CSROnly>
-)
-```
-
 ## withAsyncBoundary
 
 <Callout type='warning'>

--- a/docs/v1/src/pages/docs/react/AsyncBoundary.ko.mdx
+++ b/docs/v1/src/pages/docs/react/AsyncBoundary.ko.mdx
@@ -52,7 +52,7 @@ type AsyncBoundaryProps = Omit<SuspenseProps, 'fallback'> &
 
 <Callout type='warning'>
 
-deprecated: [wrap.ErrorBoundary().Suspense().on](./wrap), [wrap.ErrorBoundary().Suspense.CSROnly().on](./wrap)을 대신 사용하세요
+deprecated: [wrap.ErrorBoundary().Suspense().on](./wrap)을 대신 사용하세요
 
 </Callout>
 

--- a/docs/v1/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.en.mdx
@@ -53,7 +53,7 @@ If you want to use Suspense working in both SSR/CSR, You can change `<Suspense c
 
 <Callout type='warning'>
 
-deprecated: Use [wrap.Suspense().on](./wrap), [wrap.Suspense.CSROnly().on](./wrap) instead
+deprecated: Use [wrap.Suspense().on](./wrap) instead
 
 </Callout>
 

--- a/docs/v1/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.en.mdx
@@ -27,15 +27,15 @@ Control multiple `<Suspense/>`s default fallback with `<SuspensiveProvider/>`. D
 
 </Callout>
 
-### Avoid Server side rendering (csrOnly)
+### Avoid Server side rendering (clientOnly)
 
-`<Suspense csrOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+`<Suspense clientOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
 
-```tsx /csrOnly/
+```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense csrOnly fallback={<Loading />}>
+  <Suspense clientOnly fallback={<Loading />}>
     <Children />
   </Suspense>
 )
@@ -43,9 +43,9 @@ const Example = () => (
 
 <Callout type='info'>
 
-Migration support SSR gradually (`<Suspense csrOnly/>` -> `<Suspense/>`)
+Migration support SSR gradually (`<Suspense clientOnly/>` -> `<Suspense/>`)
 
-If you want to use Suspense working in both SSR/CSR, You can change `<Suspense csrOnly/>` to `<Suspense/>` gradually.
+If you want to use Suspense working in both SSR/CSR, You can change `<Suspense clientOnly/>` to `<Suspense/>` gradually.
 
 </Callout>
 
@@ -61,19 +61,10 @@ You can use withSuspense to wrap component by `<Suspense/>` easily.
 we don't need to make unncessary code to wrap it if we use withSuspense like below.
 withSuspense's 2nd parameter is props of `<Suspense/>` without children
 
-```tsx /withSuspense.CSROnly/ /withSuspense/
+```jsx /withSuspense/
 import { withSuspense } from '@suspensive/react'
 
 const Example = withSuspense(
-  function Component() {
-    // code make suspending
-
-    return <>...</>
-  },
-  { fallback: <Spinner /> }
-)
-
-const Example = withSuspense.CSROnly(
   function Component() {
     // code make suspending
 

--- a/docs/v1/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.en.mdx
@@ -27,25 +27,25 @@ Control multiple `<Suspense/>`s default fallback with `<SuspensiveProvider/>`. D
 
 </Callout>
 
-### Avoid Server side rendering (CSROnly)
+### Avoid Server side rendering (csrOnly)
 
-`<Suspense.CSROnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+`<Suspense csrOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
 
-```tsx /Suspense.CSROnly/
+```tsx /csrOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense.CSROnly fallback={<Loading />}>
+  <Suspense csrOnly fallback={<Loading />}>
     <Children />
-  </Suspense.CSROnly>
+  </Suspense>
 )
 ```
 
 <Callout type='info'>
 
-Migration support SSR gradually (`<Suspense.CSROnly/>` -> `<Suspense/>`)
+Migration support SSR gradually (`<Suspense csrOnly/>` -> `<Suspense/>`)
 
-If you want to use Suspense working in both SSR/CSR, You can change `<Suspense.CSROnly/>` to `<Suspense/>` gradually.
+If you want to use Suspense working in both SSR/CSR, You can change `<Suspense csrOnly/>` to `<Suspense/>` gradually.
 
 </Callout>
 

--- a/docs/v1/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.en.mdx
@@ -29,7 +29,7 @@ Control multiple `<Suspense/>`s default fallback with `<SuspensiveProvider/>`. D
 
 ### Avoid Server side rendering (clientOnly)
 
-`<Suspense clientOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+If you use clientOnly prop, `<Suspense/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
 
 ```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'

--- a/docs/v1/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.ko.mdx
@@ -28,7 +28,7 @@ Default fallback
 
 ### 서버사이드 렌더링을 피하기 (clientOnly)
 
-`<Suspense clientOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
+clientOnly prop을 사용하면 `<Suspense/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
 
 ```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'

--- a/docs/v1/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.ko.mdx
@@ -52,7 +52,7 @@ React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense csrO
 
 <Callout type='warning'>
 
-deprecated: [wrap.Suspense().on](./wrap), [wrap.Suspense.CSROnly().on](./wrap)을 사용하세요
+deprecated: [wrap.Suspense().on](./wrap)을 사용하세요
 
 </Callout>
 

--- a/docs/v1/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.ko.mdx
@@ -26,25 +26,25 @@ Default fallback
 
 </Callout>
 
-### 서버사이드 렌더링을 피하기 (CSROnly)
+### 서버사이드 렌더링을 피하기 (csrOnly)
 
-`<Suspense.CSROnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
+`<Suspense csrOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
 
-```tsx /Suspense.CSROnly/
+```tsx /csrOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense.CSROnly fallback={<Loading />}>
+  <Suspense csrOnly fallback={<Loading />}>
     <Children />
-  </Suspense.CSROnly>
+  </Suspense>
 )
 ```
 
 <Callout type='info'>
 
-SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense.CSROnly/>` -> `<Suspense/>`)
+SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense csrOnly/>` -> `<Suspense/>`)
 
-React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense.CSROnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
+React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense csrOnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
 
 </Callout>
 

--- a/docs/v1/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v1/src/pages/docs/react/Suspense.ko.mdx
@@ -26,15 +26,15 @@ Default fallback
 
 </Callout>
 
-### 서버사이드 렌더링을 피하기 (csrOnly)
+### 서버사이드 렌더링을 피하기 (clientOnly)
 
-`<Suspense csrOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
+`<Suspense clientOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
 
-```tsx /csrOnly/
+```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense csrOnly fallback={<Loading />}>
+  <Suspense clientOnly fallback={<Loading />}>
     <Children />
   </Suspense>
 )
@@ -42,9 +42,9 @@ const Example = () => (
 
 <Callout type='info'>
 
-SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense csrOnly/>` -> `<Suspense/>`)
+SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense clientOnly/>` -> `<Suspense/>`)
 
-React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense csrOnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
+React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense clientOnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
 
 </Callout>
 
@@ -60,19 +60,10 @@ withSuspense를 사용하면 컴포넌트를 `<Suspense/>`로 쉽게 래핑할 �
 아래와 같이 withSuspense를 사용하면 이를 감싸기 위해 불필요한 코드를 만들 필요가 없습니다.
 withSuspense의 두 번째 인자는 children이 없는 `<Suspense/>`의 props입니다.
 
-```tsx /withSuspense.CSROnly/ /withSuspense/
+```jsx /withSuspense/
 import { withSuspense } from '@suspensive/react'
 
 const Example = withSuspense(
-  function Component() {
-    // code make suspending
-
-    return <>...</>
-  },
-  { fallback: <Spinner /> }
-)
-
-const Example = withSuspense.CSROnly(
   function Component() {
     // code make suspending
 

--- a/docs/v1/src/pages/docs/react/SuspensiveProvider.en.mdx
+++ b/docs/v1/src/pages/docs/react/SuspensiveProvider.en.mdx
@@ -12,6 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
+      csrOnly: true
     },
   },
 })

--- a/docs/v1/src/pages/docs/react/SuspensiveProvider.en.mdx
+++ b/docs/v1/src/pages/docs/react/SuspensiveProvider.en.mdx
@@ -12,7 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
-      csrOnly: false,
+      clientOnly: false,
     },
   },
 })

--- a/docs/v1/src/pages/docs/react/SuspensiveProvider.en.mdx
+++ b/docs/v1/src/pages/docs/react/SuspensiveProvider.en.mdx
@@ -2,7 +2,7 @@
 
 This component controls the settings of the components provided by Suspensive (Suspense, Delay, etc.) at once.
 
-```tsx /SuspensiveProvider/ /Suspensive/
+```jsx /SuspensiveProvider/ /Suspensive/
 import { Suspensive, SuspensiveProvider } from '@suspensive/react'
 
 const suspensive = new Suspensive({
@@ -12,7 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
-      csrOnly: true
+      csrOnly: false,
     },
   },
 })

--- a/docs/v1/src/pages/docs/react/SuspensiveProvider.ko.mdx
+++ b/docs/v1/src/pages/docs/react/SuspensiveProvider.ko.mdx
@@ -2,7 +2,7 @@
 
 이 컴포넌트는 Suspensive가 제공하는 컴포넌트들(Suspense, Delay 등)의 설정을 한 번에 제어합니다.
 
-```tsx /SuspensiveProvider/ /Suspensive/
+```jsx /SuspensiveProvider/ /Suspensive/
 import { Suspensive, SuspensiveProvider } from '@suspensive/react'
 
 const suspensive = new Suspensive({
@@ -12,6 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
+      csrOnly: false,
     },
   },
 })

--- a/docs/v1/src/pages/docs/react/SuspensiveProvider.ko.mdx
+++ b/docs/v1/src/pages/docs/react/SuspensiveProvider.ko.mdx
@@ -12,7 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
-      csrOnly: false,
+      clientOnly: false,
     },
   },
 })

--- a/docs/v1/src/pages/docs/why.en.mdx
+++ b/docs/v1/src/pages/docs/why.en.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 If you have used React Suspense in SSR environment like Next.js, you may encounter error like below.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-It's why [`<Suspense/>` and `<Suspense.CSROnly/>`](/docs/react/Suspense) is added in this library.
+It's why [`<Suspense csrOnly/>`](/docs/react/Suspense) is added in this library.
 
 ### ErrorBoundary more simply
 

--- a/docs/v1/src/pages/docs/why.en.mdx
+++ b/docs/v1/src/pages/docs/why.en.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 If you have used React Suspense in SSR environment like Next.js, you may encounter error like below.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-It's why [`<Suspense csrOnly/>`](/docs/react/Suspense) is added in this library.
+It's why [`<Suspense clientOnly/>`](/docs/react/Suspense) is added in this library.
 
 ### ErrorBoundary more simply
 

--- a/docs/v1/src/pages/docs/why.en.mdx
+++ b/docs/v1/src/pages/docs/why.en.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 If you have used React Suspense in SSR environment like Next.js, you may encounter error like below.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-It's why [`<Suspense clientOnly/>`](/docs/react/Suspense) is added in this library.
+It's why [clientOnly prop of `<Suspense/>`](/docs/react/Suspense) is added in this library.
 
 ### ErrorBoundary more simply
 

--- a/docs/v1/src/pages/docs/why.ko.mdx
+++ b/docs/v1/src/pages/docs/why.ko.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 React Suspense를 Next.js와 같은 서버사이드 렌더링 환경에서 사용해본 적이 있다면 아마 종종 아래 사진과 같은 에러를 겪게 된 적이 있을 겁니다.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-이것이 [`<Suspense clientOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
+이것이 [`<Suspense/>`](/docs/react/Suspense)의 clientOnly를 이 라이브러리에 추가한 이유입니다.
 
 ### ErrorBoundary를 더욱 단순하게 사용하고 싶습니다.
 

--- a/docs/v1/src/pages/docs/why.ko.mdx
+++ b/docs/v1/src/pages/docs/why.ko.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 React Suspense를 Next.js와 같은 서버사이드 렌더링 환경에서 사용해본 적이 있다면 아마 종종 아래 사진과 같은 에러를 겪게 된 적이 있을 겁니다.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-이것이 [`<Suspense/>` 와 `<Suspense.CSROnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
+이것이 [`<Suspense csrOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
 
 ### ErrorBoundary를 더욱 단순하게 사용하고 싶습니다.
 

--- a/docs/v1/src/pages/docs/why.ko.mdx
+++ b/docs/v1/src/pages/docs/why.ko.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 React Suspense를 Next.js와 같은 서버사이드 렌더링 환경에서 사용해본 적이 있다면 아마 종종 아래 사진과 같은 에러를 겪게 된 적이 있을 겁니다.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-이것이 [`<Suspense csrOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
+이것이 [`<Suspense clientOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
 
 ### ErrorBoundary를 더욱 단순하게 사용하고 싶습니다.
 

--- a/docs/v1/src/pages/index.en.mdx
+++ b/docs/v1/src/pages/index.en.mdx
@@ -20,7 +20,7 @@ import { HomePage } from '../components/HomePage.tsx'
     },
     {
       title: 'Suspense in SSR easily',
-      desc: 'Suspensive provide CSROnly that make developer can adopt React Suspense gradually in Server-side rendering environment',
+      desc: 'Suspensive provide clientOnly that make developer can adopt React Suspense gradually in Server-side rendering environment',
     },
   ]}
 />

--- a/docs/v1/src/pages/index.ko.mdx
+++ b/docs/v1/src/pages/index.ko.mdx
@@ -20,7 +20,7 @@ import { HomePage } from '../components/HomePage.tsx'
     },
     {
       title: '서버 사이드 렌더링에서도 쉽게',
-      desc: 'Suspensive는 개발자가 서버 사이드 렌더링 환경에서도 React Suspense를 점진적으로 채택할 수 있도록 CSROnly를 제공합니다',
+      desc: 'Suspensive는 개발자가 서버 사이드 렌더링 환경에서도 React Suspense를 점진적으로 채택할 수 있도록 clientOnly를 제공합니다',
     },
   ]}
 />

--- a/docs/v1/theme.config.tsx
+++ b/docs/v1/theme.config.tsx
@@ -1,8 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router.js'
-import type { DocsThemeConfig } from 'nextra-theme-docs'
-import { useConfig } from 'nextra-theme-docs'
+import { type DocsThemeConfig, useConfig } from 'nextra-theme-docs'
 
 const localeBanner = {
   en: (

--- a/docs/v2/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v2/src/pages/docs/react/Suspense.en.mdx
@@ -27,24 +27,24 @@ Control multiple `<Suspense/>`s default fallback with `<SuspensiveProvider/>`. D
 
 </Callout>
 
-### Avoid Server side rendering (CSROnly)
+### Avoid Server side rendering (csrOnly)
 
-`<Suspense.CSROnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+`<Suspense csrOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
 
-```tsx /Suspense.CSROnly/
+```tsx /csrOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense.CSROnly fallback={<Loading />}>
+  <Suspense csrOnly fallback={<Loading />}>
     <Children />
-  </Suspense.CSROnly>
+  </Suspense>
 )
 ```
 
 <Callout type='info'>
 
-Migration support SSR gradually (`<Suspense.CSROnly/>` -> `<Suspense/>`)
+Migration support SSR gradually (`<Suspense csrOnly/>` -> `<Suspense/>`)
 
-If you want to use Suspense working in both SSR/CSR, You can change `<Suspense.CSROnly/>` to `<Suspense/>` gradually.
+If you want to use Suspense working in both SSR/CSR, You can change `<Suspense csrOnly/>` to `<Suspense/>` gradually.
 
 </Callout>

--- a/docs/v2/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v2/src/pages/docs/react/Suspense.en.mdx
@@ -27,15 +27,15 @@ Control multiple `<Suspense/>`s default fallback with `<SuspensiveProvider/>`. D
 
 </Callout>
 
-### Avoid Server side rendering (csrOnly)
+### Avoid Server side rendering (clientOnly)
 
-`<Suspense csrOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+`<Suspense clientOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
 
-```tsx /csrOnly/
+```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense csrOnly fallback={<Loading />}>
+  <Suspense clientOnly fallback={<Loading />}>
     <Children />
   </Suspense>
 )
@@ -43,8 +43,8 @@ const Example = () => (
 
 <Callout type='info'>
 
-Migration support SSR gradually (`<Suspense csrOnly/>` -> `<Suspense/>`)
+Migration support SSR gradually (`<Suspense clientOnly/>` -> `<Suspense/>`)
 
-If you want to use Suspense working in both SSR/CSR, You can change `<Suspense csrOnly/>` to `<Suspense/>` gradually.
+If you want to use Suspense working in both SSR/CSR, You can change `<Suspense clientOnly/>` to `<Suspense/>` gradually.
 
 </Callout>

--- a/docs/v2/src/pages/docs/react/Suspense.en.mdx
+++ b/docs/v2/src/pages/docs/react/Suspense.en.mdx
@@ -29,7 +29,7 @@ Control multiple `<Suspense/>`s default fallback with `<SuspensiveProvider/>`. D
 
 ### Avoid Server side rendering (clientOnly)
 
-`<Suspense clientOnly/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+If you use clientOnly prop, `<Suspense/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
 
 ```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'

--- a/docs/v2/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v2/src/pages/docs/react/Suspense.ko.mdx
@@ -28,7 +28,7 @@ Default fallback
 
 ### 서버사이드 렌더링을 피하기 (clientOnly)
 
-`<Suspense clientOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
+clientOnly prop을 사용하면 `<Suspense/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
 
 ```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'

--- a/docs/v2/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v2/src/pages/docs/react/Suspense.ko.mdx
@@ -26,24 +26,24 @@ Default fallback
 
 </Callout>
 
-### 서버사이드 렌더링을 피하기 (CSROnly)
+### 서버사이드 렌더링을 피하기 (csrOnly)
 
-`<Suspense.CSROnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
+`<Suspense csrOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
 
-```tsx /Suspense.CSROnly/
+```tsx /csrOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense.CSROnly fallback={<Loading />}>
+  <Suspense csrOnly fallback={<Loading />}>
     <Children />
-  </Suspense.CSROnly>
+  </Suspense>
 )
 ```
 
 <Callout type='info'>
 
-SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense.CSROnly/>` -> `<Suspense/>`)
+SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense csrOnly/>` -> `<Suspense/>`)
 
-React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense.CSROnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
+React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense csrOnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
 
 </Callout>

--- a/docs/v2/src/pages/docs/react/Suspense.ko.mdx
+++ b/docs/v2/src/pages/docs/react/Suspense.ko.mdx
@@ -26,15 +26,15 @@ Default fallback
 
 </Callout>
 
-### 서버사이드 렌더링을 피하기 (csrOnly)
+### 서버사이드 렌더링을 피하기 (clientOnly)
 
-`<Suspense csrOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
+`<Suspense clientOnly/>`는 서버에서는 fallback을 반환합니다. mount 후(클라이언트에서는) children을 반환합니다. mount는 클라이언트에서만 일어나기 때문에 서버사이드 렌더링을 피할 수 있습니다.
 
-```tsx /csrOnly/
+```tsx /clientOnly/
 import { Suspense } from '@suspensive/react'
 
 const Example = () => (
-  <Suspense csrOnly fallback={<Loading />}>
+  <Suspense clientOnly fallback={<Loading />}>
     <Children />
   </Suspense>
 )
@@ -42,8 +42,8 @@ const Example = () => (
 
 <Callout type='info'>
 
-SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense csrOnly/>` -> `<Suspense/>`)
+SSR을 지원하도록 점진적으로 마이그레이션하기 (`<Suspense clientOnly/>` -> `<Suspense/>`)
 
-React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense csrOnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
+React.Suspense를 SSR과 CSR에서 모두 사용하고 싶다면 `<Suspense clientOnly/>`에서 `<Suspense/>`로 점진적으로 마이그레이션하면 쉽게 적용할 수 있습니다.
 
 </Callout>

--- a/docs/v2/src/pages/docs/react/SuspensiveProvider.en.mdx
+++ b/docs/v2/src/pages/docs/react/SuspensiveProvider.en.mdx
@@ -12,7 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
-      csrOnly: false,
+      clientOnly: false,
     },
   },
 })

--- a/docs/v2/src/pages/docs/react/SuspensiveProvider.en.mdx
+++ b/docs/v2/src/pages/docs/react/SuspensiveProvider.en.mdx
@@ -1,10 +1,8 @@
-import { Callout } from 'nextra/components'
-
 # SuspensiveProvider
 
 This component controls the settings of the components provided by Suspensive (Suspense, Delay, etc.) at once.
 
-```tsx /SuspensiveProvider/ /Suspensive/
+```jsx /SuspensiveProvider/ /Suspensive/
 import { Suspensive, SuspensiveProvider } from '@suspensive/react'
 
 const suspensive = new Suspensive({
@@ -14,6 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
+      csrOnly: false,
     },
   },
 })

--- a/docs/v2/src/pages/docs/react/SuspensiveProvider.ko.mdx
+++ b/docs/v2/src/pages/docs/react/SuspensiveProvider.ko.mdx
@@ -12,7 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
-      csrOnly: false,
+      clientOnly: false,
     },
   },
 })

--- a/docs/v2/src/pages/docs/react/SuspensiveProvider.ko.mdx
+++ b/docs/v2/src/pages/docs/react/SuspensiveProvider.ko.mdx
@@ -1,10 +1,8 @@
-import { Callout } from 'nextra/components'
-
 # SuspensiveProvider
 
 이 컴포넌트는 Suspensive가 제공하는 컴포넌트들(Suspense, Delay 등)의 설정을 한 번에 제어합니다.
 
-```tsx /SuspensiveProvider/ /Suspensive/
+```jsx /SuspensiveProvider/ /Suspensive/
 import { Suspensive, SuspensiveProvider } from '@suspensive/react'
 
 const suspensive = new Suspensive({
@@ -14,6 +12,7 @@ const suspensive = new Suspensive({
     },
     suspense: {
       fallback: <Spinner />,
+      csrOnly: false,
     },
   },
 })

--- a/docs/v2/src/pages/docs/why.en.mdx
+++ b/docs/v2/src/pages/docs/why.en.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 If you have used React Suspense in SSR environment like Next.js, you may encounter error like below.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-It's why [`<Suspense/>` and `<Suspense.CSROnly/>`](/docs/react/Suspense) is added in this library.
+It's why [`<Suspense csrOnly/>`](/docs/react/Suspense) is added in this library.
 
 ### ErrorBoundary more simply
 

--- a/docs/v2/src/pages/docs/why.en.mdx
+++ b/docs/v2/src/pages/docs/why.en.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 If you have used React Suspense in SSR environment like Next.js, you may encounter error like below.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-It's why [`<Suspense csrOnly/>`](/docs/react/Suspense) is added in this library.
+It's why [`<Suspense clientOnly/>`](/docs/react/Suspense) is added in this library.
 
 ### ErrorBoundary more simply
 

--- a/docs/v2/src/pages/docs/why.en.mdx
+++ b/docs/v2/src/pages/docs/why.en.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 If you have used React Suspense in SSR environment like Next.js, you may encounter error like below.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-It's why [`<Suspense clientOnly/>`](/docs/react/Suspense) is added in this library.
+It's why [clientOnly prop of `<Suspense/>`](/docs/react/Suspense) is added in this library.
 
 ### ErrorBoundary more simply
 

--- a/docs/v2/src/pages/docs/why.ko.mdx
+++ b/docs/v2/src/pages/docs/why.ko.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 React Suspense를 Next.js와 같은 서버사이드 렌더링 환경에서 사용해본 적이 있다면 아마 종종 아래 사진과 같은 에러를 겪게 된 적이 있을 겁니다.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-이것이 [`<Suspense clientOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
+이것이 [`<Suspense/>`](/docs/react/Suspense)의 clientOnly를 이 라이브러리에 추가한 이유입니다.
 
 ### ErrorBoundary를 더욱 단순하게 사용하고 싶습니다.
 

--- a/docs/v2/src/pages/docs/why.ko.mdx
+++ b/docs/v2/src/pages/docs/why.ko.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 React Suspense를 Next.js와 같은 서버사이드 렌더링 환경에서 사용해본 적이 있다면 아마 종종 아래 사진과 같은 에러를 겪게 된 적이 있을 겁니다.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-이것이 [`<Suspense/>` 와 `<Suspense.CSROnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
+이것이 [`<Suspense csrOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
 
 ### ErrorBoundary를 더욱 단순하게 사용하고 싶습니다.
 

--- a/docs/v2/src/pages/docs/why.ko.mdx
+++ b/docs/v2/src/pages/docs/why.ko.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 React Suspense를 Next.js와 같은 서버사이드 렌더링 환경에서 사용해본 적이 있다면 아마 종종 아래 사진과 같은 에러를 겪게 된 적이 있을 겁니다.
 ![Example banner](/img/suspense-in-ssr-error.png)
 
-이것이 [`<Suspense csrOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
+이것이 [`<Suspense clientOnly/>`](/docs/react/Suspense)를 이 라이브러리에 추가한 이유입니다.
 
 ### ErrorBoundary를 더욱 단순하게 사용하고 싶습니다.
 

--- a/docs/v2/src/pages/index.en.mdx
+++ b/docs/v2/src/pages/index.en.mdx
@@ -20,7 +20,7 @@ import { HomePage } from '../components/HomePage.tsx'
     },
     {
       title: 'Suspense in SSR easily',
-      desc: 'Suspensive provide CSROnly that make developer can adopt React Suspense gradually in Server-side rendering environment',
+      desc: 'Suspensive provide clientOnly that make developer can adopt React Suspense gradually in Server-side rendering environment',
     },
   ]}
 />

--- a/docs/v2/src/pages/index.ko.mdx
+++ b/docs/v2/src/pages/index.ko.mdx
@@ -20,7 +20,7 @@ import { HomePage } from '../components/HomePage.tsx'
     },
     {
       title: '서버 사이드 렌더링에서도 쉽게',
-      desc: 'Suspensive는 개발자가 서버 사이드 렌더링 환경에서도 React Suspense를 점진적으로 채택할 수 있도록 CSROnly를 제공합니다',
+      desc: 'Suspensive는 개발자가 서버 사이드 렌더링 환경에서도 React Suspense를 점진적으로 채택할 수 있도록 clientOnly를 제공합니다',
     },
   ]}
 />

--- a/docs/v2/theme.config.tsx
+++ b/docs/v2/theme.config.tsx
@@ -1,8 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router.js'
-import type { DocsThemeConfig } from 'nextra-theme-docs'
-import { useConfig } from 'nextra-theme-docs'
+import { type DocsThemeConfig, useConfig } from 'nextra-theme-docs'
 
 const localeBanner = {
   en: (

--- a/packages/react-query/src/QueryAsyncBoundary.tsx
+++ b/packages/react-query/src/QueryAsyncBoundary.tsx
@@ -42,11 +42,11 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 /**
- * @deprecated Use `<QueryErrorBoundary/>`, `<Suspense/>` at once as alternatives
+ * @deprecated Use `<QueryErrorBoundary/>`, `<Suspense/>` at once instead
  */
 export const QueryAsyncBoundary = Object.assign(BaseQueryAsyncBoundary, {
   /**
-   * @deprecated Use `<QueryErrorBoundary/>`, `<Suspense.CSROnly/>` at once as alternatives
+   * @deprecated Use `<QueryErrorBoundary/>`, `<Suspense csrOnly/>` at once instead
    */
   CSROnly,
 })

--- a/packages/react-query/src/QueryAsyncBoundary.tsx
+++ b/packages/react-query/src/QueryAsyncBoundary.tsx
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV !== 'production') {
  */
 export const QueryAsyncBoundary = Object.assign(BaseQueryAsyncBoundary, {
   /**
-   * @deprecated Use `<QueryErrorBoundary/>`, `<Suspense csrOnly/>` at once instead
+   * @deprecated Use `<QueryErrorBoundary/>`, `<Suspense clientOnly/>` at once instead
    */
   CSROnly,
 })

--- a/packages/react/src/AsyncBoundary.tsx
+++ b/packages/react/src/AsyncBoundary.tsx
@@ -13,33 +13,45 @@ export interface AsyncBoundaryProps
   rejectedFallback: ErrorBoundaryProps['fallback']
 }
 
-const BaseAsyncBoundary = forwardRef<ComponentRef<typeof ErrorBoundary>, AsyncBoundaryProps>(
-  ({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
-    <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
-      <Suspense fallback={pendingFallback}>{children}</Suspense>
-    </ErrorBoundary>
-  )
-)
-if (process.env.NODE_ENV !== 'production') {
-  BaseAsyncBoundary.displayName = 'AsyncBoundary'
-}
-const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, Omit<AsyncBoundaryProps, 'csrOnly'>>(
-  ({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
-    <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
-      <Suspense.CSROnly fallback={pendingFallback}>{children}</Suspense.CSROnly>
-    </ErrorBoundary>
-  )
-)
-if (process.env.NODE_ENV !== 'production') {
-  CSROnly.displayName = 'AsyncBoundary.CSROnly'
-}
-
 /**
  * @deprecated Use `<Suspense/>` and `<ErrorBoundary/>` instead
  */
-export const AsyncBoundary = Object.assign(BaseAsyncBoundary, {
-  /**
-   * @deprecated Use `<Suspense csrOnly />` and `<ErrorBoundary/>` instead
-   */
-  CSROnly,
-})
+export const AsyncBoundary = Object.assign(
+  (() => {
+    const BaseAsyncBoundary = forwardRef<ComponentRef<typeof ErrorBoundary>, AsyncBoundaryProps>(
+      ({ csrOnly, pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
+        <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
+          <Suspense csrOnly={csrOnly} fallback={pendingFallback}>
+            {children}
+          </Suspense>
+        </ErrorBoundary>
+      )
+    )
+    if (process.env.NODE_ENV !== 'production') {
+      BaseAsyncBoundary.displayName = 'AsyncBoundary'
+    }
+
+    return BaseAsyncBoundary
+  })(),
+  {
+    /**
+     * @deprecated Use `<Suspense csrOnly />` and `<ErrorBoundary/>` instead
+     */
+    CSROnly: (() => {
+      const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, Omit<AsyncBoundaryProps, 'csrOnly'>>(
+        ({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
+          <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
+            <Suspense csrOnly fallback={pendingFallback}>
+              {children}
+            </Suspense>
+          </ErrorBoundary>
+        )
+      )
+      if (process.env.NODE_ENV !== 'production') {
+        CSROnly.displayName = 'AsyncBoundary.CSROnly'
+      }
+
+      return CSROnly
+    })(),
+  }
+)

--- a/packages/react/src/AsyncBoundary.tsx
+++ b/packages/react/src/AsyncBoundary.tsx
@@ -19,9 +19,9 @@ export interface AsyncBoundaryProps
 export const AsyncBoundary = Object.assign(
   (() => {
     const BaseAsyncBoundary = forwardRef<ComponentRef<typeof ErrorBoundary>, AsyncBoundaryProps>(
-      ({ csrOnly, pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
+      ({ clientOnly, pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
         <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
-          <Suspense csrOnly={csrOnly} fallback={pendingFallback}>
+          <Suspense clientOnly={clientOnly} fallback={pendingFallback}>
             {children}
           </Suspense>
         </ErrorBoundary>
@@ -35,18 +35,19 @@ export const AsyncBoundary = Object.assign(
   })(),
   {
     /**
-     * @deprecated Use `<Suspense csrOnly />` and `<ErrorBoundary/>` instead
+     * @deprecated Use `<Suspense clientOnly />` and `<ErrorBoundary/>` instead
      */
     CSROnly: (() => {
-      const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, Omit<AsyncBoundaryProps, 'csrOnly'>>(
-        ({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
-          <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
-            <Suspense csrOnly fallback={pendingFallback}>
-              {children}
-            </Suspense>
-          </ErrorBoundary>
-        )
-      )
+      const CSROnly = forwardRef<
+        ComponentRef<typeof ErrorBoundary>,
+        Omit<AsyncBoundaryProps, keyof Pick<SuspenseProps, 'clientOnly'>>
+      >(({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
+        <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
+          <Suspense clientOnly fallback={pendingFallback}>
+            {children}
+          </Suspense>
+        </ErrorBoundary>
+      ))
       if (process.env.NODE_ENV !== 'production') {
         CSROnly.displayName = 'AsyncBoundary.CSROnly'
       }

--- a/packages/react/src/AsyncBoundary.tsx
+++ b/packages/react/src/AsyncBoundary.tsx
@@ -1,6 +1,6 @@
-import { type ComponentRef, type SuspenseProps, forwardRef } from 'react'
+import { type ComponentRef, forwardRef } from 'react'
 import { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary'
-import { Suspense } from './Suspense'
+import { Suspense, type SuspenseProps } from './Suspense'
 import type { PropsWithoutDevMode } from './utility-types'
 
 /**
@@ -23,7 +23,7 @@ const BaseAsyncBoundary = forwardRef<ComponentRef<typeof ErrorBoundary>, AsyncBo
 if (process.env.NODE_ENV !== 'production') {
   BaseAsyncBoundary.displayName = 'AsyncBoundary'
 }
-const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, AsyncBoundaryProps>(
+const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, Omit<AsyncBoundaryProps, 'csrOnly'>>(
   ({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
     <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
       <Suspense.CSROnly fallback={pendingFallback}>{children}</Suspense.CSROnly>

--- a/packages/react/src/AsyncBoundary.tsx
+++ b/packages/react/src/AsyncBoundary.tsx
@@ -4,7 +4,7 @@ import { Suspense } from './Suspense'
 import type { PropsWithoutDevMode } from './utility-types'
 
 /**
- * @deprecated Use SuspenseProps and ErrorBoundaryProps as alternatives
+ * @deprecated Use SuspenseProps and ErrorBoundaryProps instead
  */
 export interface AsyncBoundaryProps
   extends Omit<PropsWithoutDevMode<SuspenseProps>, 'fallback'>,
@@ -35,11 +35,11 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 /**
- * @deprecated Use `<Suspense/>` and `<ErrorBoundary/>` as alternatives
+ * @deprecated Use `<Suspense/>` and `<ErrorBoundary/>` instead
  */
 export const AsyncBoundary = Object.assign(BaseAsyncBoundary, {
   /**
-   * @deprecated Use `<Suspense/>` and `<ErrorBoundary/>` as alternatives
+   * @deprecated Use `<Suspense csrOnly />` and `<ErrorBoundary/>` instead
    */
   CSROnly,
 })

--- a/packages/react/src/Delay.tsx
+++ b/packages/react/src/Delay.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren, useContext, useState } from 'react'
-import { DelayDefaultOptionsContext } from './contexts'
+import { DelayDefaultPropsContext } from './contexts'
 import { useTimeout } from './hooks'
 
 export interface DelayProps extends PropsWithChildren {
@@ -7,8 +7,8 @@ export interface DelayProps extends PropsWithChildren {
 }
 
 export const Delay = ({ ms, children }: DelayProps) => {
-  const delayDefaultOptions = useContext(DelayDefaultOptionsContext)
-  const delayMs = ms ?? delayDefaultOptions.ms ?? 0
+  const defaultProps = useContext(DelayDefaultPropsContext)
+  const delayMs = ms ?? defaultProps.ms ?? 0
   const [isDelayed, setIsDelayed] = useState(delayMs === 0)
   useTimeout(() => setIsDelayed(true), delayMs)
   return <>{isDelayed ? children : null}</>

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -5,7 +5,7 @@ import { type PropsWithDevMode } from './utility-types'
 import { noop } from './utils'
 
 export interface SuspenseProps extends PropsWithDevMode<SuspenseDevModeOptions>, ReactSuspenseProps {
-  csrOnly?: boolean
+  clientOnly?: boolean
 }
 
 const SuspenseContextFallback = () => useContext(SuspenseDefaultOptionsContext).fallback
@@ -16,11 +16,11 @@ const SuspenseContextFallback = () => useContext(SuspenseDefaultOptionsContext).
  */
 export const Suspense = Object.assign(
   (() => {
-    const SuspenseCSROnly = (props: ReactSuspenseProps) =>
+    const SuspenseClientOnly = (props: ReactSuspenseProps) =>
       useIsClient() ? <ReactSuspense {...props} /> : <>{props.fallback}</>
 
-    const Suspense = ({ csrOnly, devMode, children, fallback = <SuspenseContextFallback /> }: SuspenseProps) => {
-      const DefinedSuspense = csrOnly ? SuspenseCSROnly : ReactSuspense
+    const Suspense = ({ clientOnly, devMode, children, fallback = <SuspenseContextFallback /> }: SuspenseProps) => {
+      const DefinedSuspense = clientOnly ? SuspenseClientOnly : ReactSuspense
       return (
         <DefinedSuspense fallback={fallback}>
           {children}
@@ -36,14 +36,14 @@ export const Suspense = Object.assign(
   })(),
   {
     /**
-     * @deprecated Use `<Suspense csrOnly/>` instead
+     * @deprecated Use `<Suspense clientOnly/>` instead
      */
     CSROnly: (() => {
       const CSROnly = ({
         devMode,
         children,
         fallback = <SuspenseContextFallback />,
-      }: Omit<SuspenseProps, 'csrOnly'>) =>
+      }: Omit<SuspenseProps, keyof Pick<SuspenseProps, 'clientOnly'>>) =>
         useIsClient() ? (
           <ReactSuspense fallback={fallback}>
             {children}

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -4,42 +4,61 @@ import { useIsClient } from './hooks'
 import { type PropsWithDevMode } from './utility-types'
 import { noop } from './utils'
 
-export interface SuspenseProps extends PropsWithDevMode<SuspenseDevModeOptions>, ReactSuspenseProps {}
+export interface SuspenseProps extends PropsWithDevMode<SuspenseDevModeOptions>, ReactSuspenseProps {
+  csrOnly?: boolean
+}
 
 const SuspenseContextFallback = () => useContext(SuspenseDefaultOptionsContext).fallback
-const DefaultSuspense = ({ devMode, children, fallback = <SuspenseContextFallback /> }: SuspenseProps) => (
-  <ReactSuspense fallback={fallback}>
-    {children}
-    {process.env.NODE_ENV !== 'production' && devMode && <SuspenseDevMode {...devMode} />}
-  </ReactSuspense>
-)
-if (process.env.NODE_ENV !== 'production') {
-  DefaultSuspense.displayName = 'Suspense'
-}
-const CSROnly = ({ devMode, children, fallback = <SuspenseContextFallback /> }: SuspenseProps) =>
-  useIsClient() ? (
-    <ReactSuspense fallback={fallback}>
-      {children}
-      {process.env.NODE_ENV !== 'production' && devMode && <SuspenseDevMode {...devMode} />}
-    </ReactSuspense>
-  ) : (
-    <>{fallback}</>
-  )
-if (process.env.NODE_ENV !== 'production') {
-  CSROnly.displayName = 'Suspense.CSROnly'
-}
 
 /**
  * This component is just wrapping React's Suspense. to use Suspense easily in Server-side rendering environment like Next.js
  * @see {@link https://suspensive.org/docs/react/Suspense}
  */
-export const Suspense = Object.assign(DefaultSuspense, {
-  /**
-   * CSROnly make Suspense can be used in SSR framework like Next.js with React 17 or under
-   * @see {@link https://suspensive.org/docs/react/Suspense}
-   */
-  CSROnly,
-})
+export const Suspense = Object.assign(
+  (() => {
+    const SuspenseCSROnly = (props: ReactSuspenseProps) =>
+      useIsClient() ? <ReactSuspense {...props} /> : <>{props.fallback}</>
+
+    const Suspense = ({ csrOnly, devMode, children, fallback = <SuspenseContextFallback /> }: SuspenseProps) => {
+      const DefinedSuspense = csrOnly ? SuspenseCSROnly : ReactSuspense
+      return (
+        <DefinedSuspense fallback={fallback}>
+          {children}
+          {process.env.NODE_ENV !== 'production' && devMode && <SuspenseDevMode {...devMode} />}
+        </DefinedSuspense>
+      )
+    }
+    if (process.env.NODE_ENV !== 'production') {
+      Suspense.displayName = 'Suspense'
+    }
+
+    return Suspense
+  })(),
+  {
+    /**
+     * @deprecated Use <Suspense csrOnly /> instead
+     */
+    CSROnly: (() => {
+      const CSROnly = ({
+        devMode,
+        children,
+        fallback = <SuspenseContextFallback />,
+      }: Omit<SuspenseProps, 'csrOnly'>) =>
+        useIsClient() ? (
+          <ReactSuspense fallback={fallback}>
+            {children}
+            {process.env.NODE_ENV !== 'production' && devMode && <SuspenseDevMode {...devMode} />}
+          </ReactSuspense>
+        ) : (
+          <>{fallback}</>
+        )
+      if (process.env.NODE_ENV !== 'production') {
+        CSROnly.displayName = 'Suspense.CSROnly'
+      }
+      return CSROnly
+    })(),
+  }
+)
 
 type SuspenseDevModeOptions = {
   /**

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -36,7 +36,7 @@ export const Suspense = Object.assign(
   })(),
   {
     /**
-     * @deprecated Use <Suspense csrOnly /> instead
+     * @deprecated Use `<Suspense csrOnly/>` instead
      */
     CSROnly: (() => {
       const CSROnly = ({

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -5,6 +5,10 @@ import { type PropsWithDevMode } from './utility-types'
 import { noop } from './utils'
 
 export interface SuspenseProps extends PropsWithDevMode<SuspenseDevModeOptions>, ReactSuspenseProps {
+  /**
+   * `<Suspense/>` will return fallback in server. After mount(in client) return children. Since mount only happens on the client, server-side rendering can be avoided.
+   * @see https://suspensive.org/docs/react/Suspense#avoid-server-side-rendering-clientonly
+   */
   clientOnly?: boolean
 }
 

--- a/packages/react/src/Suspensive.spec.tsx
+++ b/packages/react/src/Suspensive.spec.tsx
@@ -1,8 +1,10 @@
 import { FALLBACK, Suspend, TEXT } from '@suspensive/test-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import ms from 'ms'
+import { createElement, useContext } from 'react'
 import { describe, expect, it } from 'vitest'
-import { Delay, Suspense, Suspensive, SuspensiveProvider } from '.'
+import { SuspenseDefaultPropsContext } from './contexts'
+import { Delay, Suspense, type SuspenseProps, Suspensive, SuspensiveProvider } from '.'
 
 const FALLBACK_GLOBAL = 'FALLBACK_GLOBAL'
 
@@ -71,5 +73,40 @@ describe('<SuspensiveProvider/>', () => {
       </SuspensiveProvider>
     )
     expect(screen.queryByText(FALLBACK_GLOBAL)).not.toBeInTheDocument()
+  })
+
+  it('should accept defaultOptions.suspense.clientOnly to setup default clientOnly prop of Suspense. If Suspense accept no clientOnly, Suspense should use default fallback', () => {
+    let clientOnly1: SuspenseProps['clientOnly'] = undefined
+    render(
+      <SuspensiveProvider value={new Suspensive({ defaultOptions: { suspense: { clientOnly: true } } })}>
+        {createElement(() => {
+          clientOnly1 = useContext(SuspenseDefaultPropsContext).clientOnly
+          return <></>
+        })}
+      </SuspensiveProvider>
+    )
+    expect(clientOnly1).toBe(true)
+
+    let clientOnly2: SuspenseProps['clientOnly'] = undefined
+    render(
+      <SuspensiveProvider value={new Suspensive({ defaultOptions: { suspense: { clientOnly: false } } })}>
+        {createElement(() => {
+          clientOnly2 = useContext(SuspenseDefaultPropsContext).clientOnly
+          return <></>
+        })}
+      </SuspensiveProvider>
+    )
+    expect(clientOnly2).toBe(false)
+
+    const clientOnly3: SuspenseProps['clientOnly'] = undefined
+    render(
+      <SuspensiveProvider value={new Suspensive({ defaultOptions: { suspense: {} } })}>
+        {createElement(() => {
+          clientOnly2 = useContext(SuspenseDefaultPropsContext).clientOnly
+          return <></>
+        })}
+      </SuspensiveProvider>
+    )
+    expect(clientOnly3).toBeUndefined()
   })
 })

--- a/packages/react/src/Suspensive.tsx
+++ b/packages/react/src/Suspensive.tsx
@@ -1,15 +1,15 @@
 import { type ContextType, type PropsWithChildren, useMemo } from 'react'
 import {
-  DelayDefaultOptionsContext,
-  SuspenseDefaultOptionsContext,
+  DelayDefaultPropsContext,
+  SuspenseDefaultPropsContext,
   SuspensiveDevMode,
   SuspensiveDevModeContext,
 } from './contexts'
 
 export class Suspensive {
   public defaultOptions?: {
-    suspense?: ContextType<typeof SuspenseDefaultOptionsContext>
-    delay?: ContextType<typeof DelayDefaultOptionsContext>
+    suspense?: ContextType<typeof SuspenseDefaultPropsContext>
+    delay?: ContextType<typeof DelayDefaultPropsContext>
   }
   public devMode = new SuspensiveDevMode()
 
@@ -27,11 +27,11 @@ export const SuspensiveProvider = ({ value, children }: SuspensiveProviderProps)
 
   return (
     <SuspensiveDevModeContext.Provider value={value.devMode}>
-      <DelayDefaultOptionsContext.Provider value={delayDefaultOptions}>
-        <SuspenseDefaultOptionsContext.Provider value={suspenseDefaultOptions}>
+      <DelayDefaultPropsContext.Provider value={delayDefaultOptions}>
+        <SuspenseDefaultPropsContext.Provider value={suspenseDefaultOptions}>
           {children}
-        </SuspenseDefaultOptionsContext.Provider>
-      </DelayDefaultOptionsContext.Provider>
+        </SuspenseDefaultPropsContext.Provider>
+      </DelayDefaultPropsContext.Provider>
     </SuspensiveDevModeContext.Provider>
   )
 }

--- a/packages/react/src/contexts/DefaultOptionsContexts.ts
+++ b/packages/react/src/contexts/DefaultOptionsContexts.ts
@@ -1,14 +1,19 @@
 import { createContext } from 'react'
-import type { DelayProps } from '../Delay'
-import type { SuspenseProps } from '../Suspense'
-import type { PropsWithoutChildren } from '../utility-types'
+import { type DelayProps } from '../Delay'
+import { type SuspenseProps } from '../Suspense'
+import { type PropsWithoutChildren, type PropsWithoutDevMode } from '../utility-types'
 
-export const DelayDefaultOptionsContext = createContext<PropsWithoutChildren<DelayProps>>({ ms: 0 })
+export const DelayDefaultPropsContext = createContext<PropsWithoutDevMode<PropsWithoutChildren<DelayProps>>>({
+  ms: undefined,
+})
 if (process.env.NODE_ENV !== 'production') {
-  DelayDefaultOptionsContext.displayName = 'DelayDefaultOptionsContext'
+  DelayDefaultPropsContext.displayName = 'DelayDefaultPropsContext'
 }
 
-export const SuspenseDefaultOptionsContext = createContext<PropsWithoutChildren<SuspenseProps>>({ fallback: undefined })
+export const SuspenseDefaultPropsContext = createContext<PropsWithoutDevMode<PropsWithoutChildren<SuspenseProps>>>({
+  fallback: undefined,
+  clientOnly: undefined,
+})
 if (process.env.NODE_ENV !== 'production') {
-  SuspenseDefaultOptionsContext.displayName = 'SuspenseDefaultOptionsContext'
+  SuspenseDefaultPropsContext.displayName = 'SuspenseDefaultPropsContext'
 }

--- a/packages/react/src/contexts/index.ts
+++ b/packages/react/src/contexts/index.ts
@@ -1,2 +1,2 @@
-export { DelayDefaultOptionsContext, SuspenseDefaultOptionsContext } from './DefaultOptionsContexts'
+export { DelayDefaultPropsContext, SuspenseDefaultPropsContext } from './DefaultOptionsContexts'
 export { SuspensiveDevMode, useDevModeObserve, SuspensiveDevModeContext } from './SuspensiveDevModeContext'

--- a/packages/react/src/wrap.tsx
+++ b/packages/react/src/wrap.tsx
@@ -64,6 +64,9 @@ class WrapWithoutCSROnly {
 
 type Wrap = WrapWithoutCSROnly & {
   Suspense: WrapWithoutCSROnly['Suspense'] & {
+    /**
+     * @deprecated Use wrap.Suspense({ csrOnly: true }).on instead
+     */
     CSROnly: (props?: PropsWithoutChildren<ComponentProps<typeof Suspense.CSROnly>>) => Wrap
   }
 }
@@ -95,7 +98,7 @@ export const wrap = {
 }
 
 /**
- * @deprecated Use wrap.Suspense().on as alternatives
+ * @deprecated Use wrap.Suspense().on instead
  */
 export const withSuspense = Object.assign(
   <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
@@ -104,7 +107,7 @@ export const withSuspense = Object.assign(
   ) => wrap.Suspense(suspenseProps).on(component),
   {
     /**
-     * @deprecated Use wrap.Suspense.CSROnly().on as alternatives
+     * @deprecated Use wrap.Suspense({ csrOnly: true }).on instead
      */
     CSROnly: <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
       component: ComponentType<TProps>,
@@ -114,7 +117,7 @@ export const withSuspense = Object.assign(
 )
 
 /**
- * @deprecated Use wrap.ErrorBoundary().on as alternatives
+ * @deprecated Use wrap.ErrorBoundary().on instead
  */
 export const withErrorBoundary = <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
   component: ComponentType<TProps>,
@@ -122,7 +125,7 @@ export const withErrorBoundary = <TProps extends ComponentProps<ComponentType> =
 ) => wrap.ErrorBoundary(errorBoundaryProps).on(component)
 
 /**
- * @deprecated Use wrap.Delay().on as alternatives
+ * @deprecated Use wrap.Delay().on instead
  */
 export const withDelay = <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
   component: ComponentType<TProps>,
@@ -130,7 +133,7 @@ export const withDelay = <TProps extends ComponentProps<ComponentType> = Record<
 ) => wrap.Delay(delayProps).on(component)
 
 /**
- * @deprecated Use wrap.ErrorBoundaryGroup().on as alternatives
+ * @deprecated Use wrap.ErrorBoundaryGroup().on instead
  */
 export const withErrorBoundaryGroup = <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
   component: ComponentType<TProps>,
@@ -138,7 +141,7 @@ export const withErrorBoundaryGroup = <TProps extends ComponentProps<ComponentTy
 ) => wrap.ErrorBoundaryGroup(errorBoundaryGroupProps).on(component)
 
 /**
- * @deprecated Use wrap.ErrorBoundary().Suspense().on as alternatives
+ * @deprecated Use wrap.ErrorBoundary().Suspense().on instead
  */
 export const withAsyncBoundary = Object.assign(
   <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
@@ -160,7 +163,7 @@ export const withAsyncBoundary = Object.assign(
   },
   {
     /**
-     * @deprecated Use wrap.ErrorBoundary().Suspense.CSROnly().on as alternatives
+     * @deprecated Use wrap.ErrorBoundary().Suspense({ csrOnly: true }).on instead
      */
     CSROnly: <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
       Component: ComponentType<TProps>,

--- a/packages/react/src/wrap.tsx
+++ b/packages/react/src/wrap.tsx
@@ -170,9 +170,9 @@ export const withAsyncBoundary = Object.assign(
       asyncBoundaryProps: PropsWithoutChildren<AsyncBoundaryProps>
     ) => {
       const Wrapped = (props: TProps) => (
-        <AsyncBoundary.CSROnly {...asyncBoundaryProps}>
+        <AsyncBoundary {...asyncBoundaryProps} csrOnly>
           <Component {...props} />
-        </AsyncBoundary.CSROnly>
+        </AsyncBoundary>
       )
 
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/react/src/wrap.tsx
+++ b/packages/react/src/wrap.tsx
@@ -65,7 +65,7 @@ class WrapWithoutCSROnly {
 type Wrap = WrapWithoutCSROnly & {
   Suspense: WrapWithoutCSROnly['Suspense'] & {
     /**
-     * @deprecated Use wrap.Suspense({ csrOnly: true }).on instead
+     * @deprecated Use wrap.Suspense({ clientOnly: true }).on instead
      */
     CSROnly: (props?: PropsWithoutChildren<ComponentProps<typeof Suspense.CSROnly>>) => Wrap
   }
@@ -107,7 +107,7 @@ export const withSuspense = Object.assign(
   ) => wrap.Suspense(suspenseProps).on(component),
   {
     /**
-     * @deprecated Use wrap.Suspense({ csrOnly: true }).on instead
+     * @deprecated Use wrap.Suspense({ clientOnly: true }).on instead
      */
     CSROnly: <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
       component: ComponentType<TProps>,
@@ -163,14 +163,14 @@ export const withAsyncBoundary = Object.assign(
   },
   {
     /**
-     * @deprecated Use wrap.ErrorBoundary().Suspense({ csrOnly: true }).on instead
+     * @deprecated Use wrap.ErrorBoundary().Suspense({ clientOnly: true }).on instead
      */
     CSROnly: <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
       Component: ComponentType<TProps>,
-      asyncBoundaryProps: PropsWithoutChildren<AsyncBoundaryProps>
+      asyncBoundaryProps: PropsWithoutChildren<Omit<AsyncBoundaryProps, keyof Pick<SuspenseProps, 'clientOnly'>>>
     ) => {
       const Wrapped = (props: TProps) => (
-        <AsyncBoundary {...asyncBoundaryProps} csrOnly>
+        <AsyncBoundary {...asyncBoundaryProps} clientOnly>
           <Component {...props} />
         </AsyncBoundary>
       )

--- a/websites/visualization/src/app/react-await/page.tsx
+++ b/websites/visualization/src/app/react-await/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   return (
     <ErrorBoundary fallback={() => <div>error</div>}>
       <div className="flex flex-col">
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -23,7 +23,7 @@ export default function Page() {
             )}
           </Await>
         </Suspense>
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -38,7 +38,7 @@ export default function Page() {
             )}
           </Await>
         </Suspense>
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -53,7 +53,7 @@ export default function Page() {
             )}
           </Await>
         </Suspense>
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -71,7 +71,7 @@ export default function Page() {
       </div>
 
       <div className="flex flex-col">
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [3000] as const,
@@ -86,7 +86,7 @@ export default function Page() {
             )}
           </Await>
         </Suspense>
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [4000] as const,
@@ -101,7 +101,7 @@ export default function Page() {
             )}
           </Await>
         </Suspense>
-        <Suspense csrOnly fallback={<div>loading...</div>}>
+        <Suspense clientOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [4000] as const,

--- a/websites/visualization/src/app/react-await/page.tsx
+++ b/websites/visualization/src/app/react-await/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   return (
     <ErrorBoundary fallback={() => <div>error</div>}>
       <div className="flex flex-col">
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -22,8 +22,8 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        </Suspense>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -37,8 +37,8 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        </Suspense>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -52,8 +52,8 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        </Suspense>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [2000] as const,
@@ -67,11 +67,11 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
+        </Suspense>
       </div>
 
       <div className="flex flex-col">
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [3000] as const,
@@ -85,8 +85,8 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        </Suspense>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [4000] as const,
@@ -100,8 +100,8 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
-        <Suspense.CSROnly fallback={<div>loading...</div>}>
+        </Suspense>
+        <Suspense csrOnly fallback={<div>loading...</div>}>
           <Await
             options={{
               key: [4000] as const,
@@ -115,7 +115,7 @@ export default function Page() {
               </div>
             )}
           </Await>
-        </Suspense.CSROnly>
+        </Suspense>
       </div>
     </ErrorBoundary>
   )

--- a/websites/visualization/src/app/react-image/page.tsx
+++ b/websites/visualization/src/app/react-image/page.tsx
@@ -5,7 +5,7 @@ import { Image } from '@suspensive/react-image'
 
 export default wrap
   .ErrorBoundary({ fallback: () => <div>error</div> })
-  .Suspense({ csrOnly: true, fallback: 'loading...' })
+  .Suspense({ clientOnly: true, fallback: 'loading...' })
   .on(function Page() {
     return (
       <div className="flex flex-col">

--- a/websites/visualization/src/app/react-image/page.tsx
+++ b/websites/visualization/src/app/react-image/page.tsx
@@ -5,7 +5,7 @@ import { Image } from '@suspensive/react-image'
 
 export default wrap
   .ErrorBoundary({ fallback: () => <div>error</div> })
-  .Suspense.CSROnly({ fallback: 'loading...' })
+  .Suspense({ csrOnly: true, fallback: 'loading...' })
   .on(function Page() {
     return (
       <div className="flex flex-col">

--- a/websites/visualization/src/app/react-query/page.tsx
+++ b/websites/visualization/src/app/react-query/page.tsx
@@ -17,7 +17,7 @@ export default wrap.ErrorBoundaryGroup({}).on(function Page() {
       </div>
       <Area title="QueryErrorResetBoundary + ErrorBoundary + Suspense">
         <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-          <Suspense csrOnly fallback={<Spinner />}>
+          <Suspense clientOnly fallback={<Spinner />}>
             <UseSuspenseQuery queryKey={['query', 1] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
             <UseSuspenseQuery queryKey={['query', 2] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
           </Suspense>
@@ -26,7 +26,7 @@ export default wrap.ErrorBoundaryGroup({}).on(function Page() {
 
       <Area title="QueryErrorBoundary + Suspense">
         <QueryErrorBoundary fallback={RejectedFallback}>
-          <Suspense csrOnly fallback={<Spinner />}>
+          <Suspense clientOnly fallback={<Spinner />}>
             <UseSuspenseQuery queryKey={['query', 3] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
             <UseSuspenseQuery queryKey={['query', 4] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
           </Suspense>

--- a/websites/visualization/src/app/react-query/page.tsx
+++ b/websites/visualization/src/app/react-query/page.tsx
@@ -17,19 +17,19 @@ export default wrap.ErrorBoundaryGroup({}).on(function Page() {
       </div>
       <Area title="QueryErrorResetBoundary + ErrorBoundary + Suspense">
         <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-          <Suspense.CSROnly fallback={<Spinner />}>
+          <Suspense csrOnly fallback={<Spinner />}>
             <UseSuspenseQuery queryKey={['query', 1] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
             <UseSuspenseQuery queryKey={['query', 2] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
-          </Suspense.CSROnly>
+          </Suspense>
         </ErrorBoundary>
       </Area>
 
       <Area title="QueryErrorBoundary + Suspense">
         <QueryErrorBoundary fallback={RejectedFallback}>
-          <Suspense.CSROnly fallback={<Spinner />}>
+          <Suspense csrOnly fallback={<Spinner />}>
             <UseSuspenseQuery queryKey={['query', 3] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
             <UseSuspenseQuery queryKey={['query', 4] as const} queryFn={() => api.delay(500, { percentage: 40 })} />
-          </Suspense.CSROnly>
+          </Suspense>
         </QueryErrorBoundary>
       </Area>
     </Area>

--- a/websites/visualization/src/app/react/page.tsx
+++ b/websites/visualization/src/app/react/page.tsx
@@ -21,7 +21,7 @@ export default function Page() {
               <ErrorBoundaryGroup.Reset trigger={(group) => <Button onClick={group.reset}>↻</Button>} />
             </div>
             <Area title="Suspense (Continuous 3 fetching)">
-              <Suspense csrOnly fallback={<Spinner />}>
+              <Suspense clientOnly fallback={<Spinner />}>
                 <UseSuspenseQuery queryKey={['boundary', 1]} queryFn={() => api.delay(500, { percentage: 100 })} />
                 <UseSuspenseQuery queryKey={['boundary', 2]} queryFn={() => api.delay(1000, { percentage: 100 })} />
                 <UseSuspenseQuery queryKey={['boundary', 3]} queryFn={() => api.delay(1500, { percentage: 100 })} />
@@ -30,7 +30,7 @@ export default function Page() {
 
             <Area title="ErrorBoundary (100% Error)">
               <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-                <Suspense csrOnly fallback={<Spinner />}>
+                <Suspense clientOnly fallback={<Spinner />}>
                   <UseSuspenseQuery queryKey={['boundary', 4]} queryFn={() => api.delay(500, { percentage: 0 })} />
                   <UseSuspenseQuery queryKey={['boundary', 5]} queryFn={() => api.delay(500, { percentage: 100 })} />
                 </Suspense>
@@ -45,14 +45,14 @@ export default function Page() {
               <ErrorBoundaryGroup.Reset trigger={(group) => <Button onClick={group.reset}>↻</Button>} />
             </div>
             <Area title="Suspense">
-              <Suspense csrOnly fallback={<Spinner />}>
+              <Suspense clientOnly fallback={<Spinner />}>
                 <UseSuspenseQuery queryKey={['boundary', 1]} queryFn={() => api.delay(500, { percentage: 100 })} />
               </Suspense>
             </Area>
 
             <Area title="ErrorBoundary (100% Error)">
               <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-                <Suspense csrOnly fallback={<Spinner />}>
+                <Suspense clientOnly fallback={<Spinner />}>
                   <UseSuspenseQuery queryKey={['boundary', 4]} queryFn={() => api.delay(500, { percentage: 0 })} />
                   <UseSuspenseQuery queryKey={['boundary', 5]} queryFn={() => api.delay(500, { percentage: 100 })} />
                 </Suspense>
@@ -63,7 +63,7 @@ export default function Page() {
 
         <Area title="ErrorBoundary (100% Error)">
           <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-            <Suspense csrOnly fallback={<Spinner />}>
+            <Suspense clientOnly fallback={<Spinner />}>
               <UseSuspenseQuery queryKey={['boundary', 4]} queryFn={() => api.delay(500, { percentage: 0 })} />
               <UseSuspenseQuery queryKey={['boundary', 5]} queryFn={() => api.delay(500, { percentage: 100 })} />
             </Suspense>

--- a/websites/visualization/src/app/react/page.tsx
+++ b/websites/visualization/src/app/react/page.tsx
@@ -21,19 +21,19 @@ export default function Page() {
               <ErrorBoundaryGroup.Reset trigger={(group) => <Button onClick={group.reset}>↻</Button>} />
             </div>
             <Area title="Suspense (Continuous 3 fetching)">
-              <Suspense.CSROnly fallback={<Spinner />}>
+              <Suspense csrOnly fallback={<Spinner />}>
                 <UseSuspenseQuery queryKey={['boundary', 1]} queryFn={() => api.delay(500, { percentage: 100 })} />
                 <UseSuspenseQuery queryKey={['boundary', 2]} queryFn={() => api.delay(1000, { percentage: 100 })} />
                 <UseSuspenseQuery queryKey={['boundary', 3]} queryFn={() => api.delay(1500, { percentage: 100 })} />
-              </Suspense.CSROnly>
+              </Suspense>
             </Area>
 
             <Area title="ErrorBoundary (100% Error)">
               <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-                <Suspense.CSROnly fallback={<Spinner />}>
+                <Suspense csrOnly fallback={<Spinner />}>
                   <UseSuspenseQuery queryKey={['boundary', 4]} queryFn={() => api.delay(500, { percentage: 0 })} />
                   <UseSuspenseQuery queryKey={['boundary', 5]} queryFn={() => api.delay(500, { percentage: 100 })} />
-                </Suspense.CSROnly>
+                </Suspense>
               </ErrorBoundary>
             </Area>
           </ErrorBoundaryGroup>
@@ -45,17 +45,17 @@ export default function Page() {
               <ErrorBoundaryGroup.Reset trigger={(group) => <Button onClick={group.reset}>↻</Button>} />
             </div>
             <Area title="Suspense">
-              <Suspense.CSROnly fallback={<Spinner />}>
+              <Suspense csrOnly fallback={<Spinner />}>
                 <UseSuspenseQuery queryKey={['boundary', 1]} queryFn={() => api.delay(500, { percentage: 100 })} />
-              </Suspense.CSROnly>
+              </Suspense>
             </Area>
 
             <Area title="ErrorBoundary (100% Error)">
               <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-                <Suspense.CSROnly fallback={<Spinner />}>
+                <Suspense csrOnly fallback={<Spinner />}>
                   <UseSuspenseQuery queryKey={['boundary', 4]} queryFn={() => api.delay(500, { percentage: 0 })} />
                   <UseSuspenseQuery queryKey={['boundary', 5]} queryFn={() => api.delay(500, { percentage: 100 })} />
-                </Suspense.CSROnly>
+                </Suspense>
               </ErrorBoundary>
             </Area>
           </ErrorBoundaryGroup>
@@ -63,10 +63,10 @@ export default function Page() {
 
         <Area title="ErrorBoundary (100% Error)">
           <ErrorBoundary onReset={queryErrorResetBoundary.reset} fallback={RejectedFallback}>
-            <Suspense.CSROnly fallback={<Spinner />}>
+            <Suspense csrOnly fallback={<Spinner />}>
               <UseSuspenseQuery queryKey={['boundary', 4]} queryFn={() => api.delay(500, { percentage: 0 })} />
               <UseSuspenseQuery queryKey={['boundary', 5]} queryFn={() => api.delay(500, { percentage: 100 })} />
-            </Suspense.CSROnly>
+            </Suspense>
           </ErrorBoundary>
         </Area>
       </ErrorBoundaryGroup>

--- a/websites/visualization/src/app/react/wrap/page.tsx
+++ b/websites/visualization/src/app/react/wrap/page.tsx
@@ -7,7 +7,7 @@ const logError = (error: Error) => console.error(error)
 const Page = wrap
   .ErrorBoundaryGroup({ blockOutside: false })
   .ErrorBoundary({ fallback: (props) => <div>{props.error.message}</div>, onError: logError })
-  .Suspense.CSROnly({ fallback: 'loading...' })
+  .Suspense({ csrOnly: true, fallback: 'loading...' })
   .on(function Page({ text }: { text: string }) {
     const errorBoundary = useErrorBoundary()
 

--- a/websites/visualization/src/app/react/wrap/page.tsx
+++ b/websites/visualization/src/app/react/wrap/page.tsx
@@ -7,7 +7,7 @@ const logError = (error: Error) => console.error(error)
 const Page = wrap
   .ErrorBoundaryGroup({ blockOutside: false })
   .ErrorBoundary({ fallback: (props) => <div>{props.error.message}</div>, onError: logError })
-  .Suspense({ csrOnly: true, fallback: 'loading...' })
+  .Suspense({ clientOnly: true, fallback: 'loading...' })
   .on(function Page({ text }: { text: string }) {
     const errorBoundary = useErrorBoundary()
 


### PR DESCRIPTION
fix #469 

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

@minsoo-web @okinawaa 
When I introduce Suspense.CSROnly to the interested, half of someone don't understand at once. In addition, we need to make depth of wrap's interface(only wrap.Suspense.CSROnly have 2 depth). It have incosistency to be understood at once.

So I replace Suspense.CSRonly by clientOnly prop of Suspense and mark it as deprecated. And I want to remove it in v2

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
