### PR TITLE
feat(*): remove target react v16, v17, unnecessary use-sync-external-store

### DIFF
--- a/.changeset/swift-moons-help.md
+++ b/.changeset/swift-moons-help.md
@@ -1,0 +1,8 @@
+---
+"@suspensive/react-await": major
+"@suspensive/react-image": major
+"@suspensive/react-query": major
+"@suspensive/react": major
+---
+
+feat(*): remove target react v16, v17

--- a/configs/test-utils/package.json
+++ b/configs/test-utils/package.json
@@ -36,6 +36,6 @@
     "react": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18"
+    "react": "^18"
   }
 }

--- a/packages/react-await/package.json
+++ b/packages/react-await/package.json
@@ -56,9 +56,6 @@
     "test:watch": "vitest --ui --coverage --typecheck",
     "type:check": "tsc --noEmit"
   },
-  "dependencies": {
-    "use-sync-external-store": "^1.2.0"
-  },
   "devDependencies": {
     "@suspensive/package-json-name": "workspace:*",
     "@suspensive/react": "workspace:*",
@@ -66,12 +63,11 @@
     "@suspensive/tsup": "workspace:*",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
-    "@types/use-sync-external-store": "^0.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18"
+    "react": "^18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-await/src/Await.tsx
+++ b/packages/react-await/src/Await.tsx
@@ -1,5 +1,4 @@
-import { type FunctionComponent, useMemo } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { type FunctionComponent, useMemo, useSyncExternalStore } from 'react'
 import type { Tuple } from './utility-types'
 import { hashKey } from './utils'
 

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -56,21 +56,17 @@
     "test:watch": "vitest --ui --coverage --typecheck",
     "type:check": "tsc --noEmit"
   },
-  "dependencies": {
-    "use-sync-external-store": "^1.2.0"
-  },
   "devDependencies": {
     "@suspensive/package-json-name": "workspace:*",
     "@suspensive/test-utils": "workspace:*",
     "@suspensive/tsup": "workspace:*",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
-    "@types/use-sync-external-store": "^0.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18"
+    "react": "^18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-image/src/Load.tsx
+++ b/packages/react-image/src/Load.tsx
@@ -1,5 +1,4 @@
-import type { FunctionComponent } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { type FunctionComponent, useSyncExternalStore } from 'react'
 
 /**
  * Loads an image from the given source URL.

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "@suspensive/react": "workspace:^1.25.0",
     "@tanstack/react-query": "^4",
-    "react": "^16.8 || ^17 || ^18"
+    "react": "^18"
   },
   "peerDependenciesMeta": {
     "@suspensive/react": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18"
+    "react": "^18"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,10 +264,6 @@ importers:
         version: 18.2.0(react@18.2.0)
 
   packages/react-await:
-    dependencies:
-      use-sync-external-store:
-        specifier: ^1.2.0
-        version: 1.2.0(react@18.2.0)
     devDependencies:
       '@suspensive/package-json-name':
         specifier: workspace:*
@@ -287,9 +283,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.18
         version: 18.2.18
-      '@types/use-sync-external-store':
-        specifier: ^0.0.6
-        version: 0.0.6
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -298,10 +291,6 @@ importers:
         version: 18.2.0(react@18.2.0)
 
   packages/react-image:
-    dependencies:
-      use-sync-external-store:
-        specifier: ^1.2.0
-        version: 1.2.0(react@18.2.0)
     devDependencies:
       '@suspensive/package-json-name':
         specifier: workspace:*
@@ -318,9 +307,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.18
         version: 18.2.18
-      '@types/use-sync-external-store':
-        specifier: ^0.0.6
-        version: 0.0.6
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2312,10 +2298,6 @@ packages:
   /@types/unist@3.0.1:
     resolution: {integrity: sha512-ue/hDUpPjC85m+PM9OQDMZr3LywT+CT6mPsQq8OJtCLiERkGRcQUFvu9XASF5XWqyZFXbf15lvb3JFJ4dRLWPg==}
     dev: false
-
-  /@types/use-sync-external-store@0.0.6:
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-    dev: true
 
   /@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-DUCUkQNklCQYnrBSSikjVChdc84/vMPDQSgJTHBZ64G9bA9w0Crc0rd2diujKbTdp6w2J47qkeHQLoi0rpLCdg==}


### PR DESCRIPTION
fix #183 

# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I remove target react v16, v17, unnecessary use-sync-external-store

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
