### PR TITLE
feat(utility-types): add isNullable utility type

### DIFF
--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -20,7 +20,7 @@ import {
   useErrorBoundaryFallbackProps_this_hook_should_be_called_in_ErrorBoundary_props_fallback,
   useErrorBoundary_this_hook_should_be_called_in_ErrorBoundary_props_children,
 } from './models/SuspensiveError'
-import type { ConstructorType, PropsWithDevMode } from './utility-types'
+import type { ConstructorType, Nullable, PropsWithDevMode } from './utility-types'
 import { hasResetKeysChanged } from './utils'
 
 export interface ErrorBoundaryFallbackProps<TError extends Error = Error> {
@@ -187,7 +187,7 @@ export const ErrorBoundary = Object.assign(
   }
 )
 
-const ErrorBoundaryContext = createContext<({ reset: () => void } & ErrorBoundaryState) | null>(null)
+const ErrorBoundaryContext = createContext<Nullable<{ reset: () => void } & ErrorBoundaryState>>(null)
 if (process.env.NODE_ENV === 'development') {
   ErrorBoundaryContext.displayName = 'ErrorBoundaryContext'
 }

--- a/packages/react/src/contexts/SuspensiveDevModeContext.ts
+++ b/packages/react/src/contexts/SuspensiveDevModeContext.ts
@@ -3,17 +3,20 @@ import { type ComponentProps, type ComponentType, createContext, createElement, 
 // https://github.com/TanStack/query/blob/v4/packages/react-query/src/useSyncExternalStore.ts
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { Subscribable } from '../models/Subscribable'
+import type { Nullable } from '../utility-types'
 import { noop } from '../utils/noop'
 
-export const DevModeContext = createContext<SuspensiveDevMode | null>(null)
+export const DevModeContext = createContext<Nullable<SuspensiveDevMode>>(null)
 
 type SyncDevMode = <TProps extends ComponentProps<ComponentType>>(
   Component: ComponentType<TProps & { devMode: SuspensiveDevMode }>
-) => (props: TProps) => React.FunctionComponentElement<
-  TProps & {
-    devMode: SuspensiveDevMode
-  }
-> | null
+) => (props: TProps) => Nullable<
+  React.FunctionComponentElement<
+    TProps & {
+      devMode: SuspensiveDevMode
+    }
+  >
+>
 
 export const syncDevMode: SyncDevMode =
   process.env.NODE_ENV === 'development'

--- a/packages/react/src/utility-types/Nullable.ts
+++ b/packages/react/src/utility-types/Nullable.ts
@@ -1,0 +1,1 @@
+export type Nullable<TData> = TData | null

--- a/packages/react/src/utility-types/index.ts
+++ b/packages/react/src/utility-types/index.ts
@@ -1,3 +1,4 @@
 export type { PropsWithDevMode } from './PropsWithDevMode'
 export type { OmitKeyOf } from './OmitKeyOf'
 export type { ConstructorType } from './ConstructorType'
+export type { Nullable } from './Nullable'


### PR DESCRIPTION
# Overview

This is a minor suggestion! 🙏

How about managing types that have `null` as a union type with an `isNullable` utility type?

These types are meaningful and could be reused enough in the future. 

However, this task may be subject to personal preferences. **The opinion of the maintainer is important...!!💪**

In the case of `vitest`, it also includes `undefined` as an `isNullable` type, but we don't seem to need it.

```tsx
// vitest
type Nullable<T> = T | null | undefined;
```

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
