### PR TITLE
fix(react): add OmitKeyof safely and test cases for it

### DIFF
--- a/.changeset/cyan-baboons-clean.md
+++ b/.changeset/cyan-baboons-clean.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix(react): add OmitKeyof safely and test cases for it

--- a/packages/react/src/AsyncBoundary.tsx
+++ b/packages/react/src/AsyncBoundary.tsx
@@ -1,14 +1,14 @@
 import { type ComponentRef, forwardRef } from 'react'
 import { ErrorBoundary, type ErrorBoundaryProps } from './ErrorBoundary'
 import { Suspense, type SuspenseProps } from './Suspense'
-import type { OmitKeyOf } from './utility-types'
+import type { OmitKeyof } from './utility-types'
 
 /**
  * @deprecated Use SuspenseProps and ErrorBoundaryProps instead
  */
 export interface AsyncBoundaryProps
-  extends OmitKeyOf<SuspenseProps, 'fallback' | 'devMode'>,
-    OmitKeyOf<ErrorBoundaryProps, 'fallback' | 'devMode'> {
+  extends OmitKeyof<SuspenseProps, 'fallback' | 'devMode'>,
+    OmitKeyof<ErrorBoundaryProps, 'fallback' | 'devMode'> {
   pendingFallback?: SuspenseProps['fallback']
   rejectedFallback: ErrorBoundaryProps['fallback']
 }
@@ -38,7 +38,7 @@ export const AsyncBoundary = Object.assign(
      * @deprecated Use `<Suspense clientOnly />` and `<ErrorBoundary/>` instead
      */
     CSROnly: (() => {
-      const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, OmitKeyOf<AsyncBoundaryProps, 'clientOnly'>>(
+      const CSROnly = forwardRef<ComponentRef<typeof ErrorBoundary>, OmitKeyof<AsyncBoundaryProps, 'clientOnly'>>(
         ({ pendingFallback, rejectedFallback, children, ...errorBoundaryProps }, resetRef) => (
           <ErrorBoundary {...errorBoundaryProps} ref={resetRef} fallback={rejectedFallback}>
             <Suspense clientOnly fallback={pendingFallback}>

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -40,7 +40,7 @@ export const Suspense = Object.assign(
      * @deprecated Use `<Suspense clientOnly/>` instead
      */
     CSROnly: (() => {
-      const Suspense = ({ devMode, children, fallback }: OmitKeyof<SuspenseProps, 'clientOnly', 'safely'>) => {
+      const Suspense = ({ devMode, children, fallback }: OmitKeyof<SuspenseProps, 'clientOnly'>) => {
         const defaultProps = useContext(SuspenseDefaultPropsContext)
         return (
           <SuspenseClientOnly fallback={typeof fallback === 'undefined' ? defaultProps.fallback : fallback}>

--- a/packages/react/src/Suspense.tsx
+++ b/packages/react/src/Suspense.tsx
@@ -1,7 +1,7 @@
 import { Suspense as ReactSuspense, type SuspenseProps as ReactSuspenseProps, useContext } from 'react'
 import { SuspenseDefaultPropsContext, syncDevMode } from './contexts'
 import { useIsClient } from './hooks'
-import type { OmitKeyOf, PropsWithDevMode } from './utility-types'
+import type { OmitKeyof, PropsWithDevMode } from './utility-types'
 
 const SuspenseClientOnly = (props: ReactSuspenseProps) =>
   useIsClient() ? <ReactSuspense {...props} /> : <>{props.fallback}</>
@@ -40,7 +40,7 @@ export const Suspense = Object.assign(
      * @deprecated Use `<Suspense clientOnly/>` instead
      */
     CSROnly: (() => {
-      const Suspense = ({ devMode, children, fallback }: OmitKeyOf<SuspenseProps, 'clientOnly'>) => {
+      const Suspense = ({ devMode, children, fallback }: OmitKeyof<SuspenseProps, 'clientOnly', 'safely'>) => {
         const defaultProps = useContext(SuspenseDefaultPropsContext)
         return (
           <SuspenseClientOnly fallback={typeof fallback === 'undefined' ? defaultProps.fallback : fallback}>

--- a/packages/react/src/contexts/DefaultOptionsContexts.ts
+++ b/packages/react/src/contexts/DefaultOptionsContexts.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react'
 import type { DelayProps, SuspenseProps } from '..'
-import type { OmitKeyOf } from '../utility-types'
+import type { OmitKeyof } from '../utility-types'
 
-export const DelayDefaultPropsContext = createContext<OmitKeyOf<DelayProps, 'children'>>({
+export const DelayDefaultPropsContext = createContext<OmitKeyof<DelayProps, 'children'>>({
   ms: undefined,
   fallback: undefined,
 })
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV === 'development') {
   DelayDefaultPropsContext.displayName = 'DelayDefaultPropsContext'
 }
 
-export const SuspenseDefaultPropsContext = createContext<OmitKeyOf<SuspenseProps, 'children' | 'devMode'>>({
+export const SuspenseDefaultPropsContext = createContext<OmitKeyof<SuspenseProps, 'children' | 'devMode'>>({
   fallback: undefined,
   clientOnly: undefined,
 })

--- a/packages/react/src/utility-types/OmitKeyOf.ts
+++ b/packages/react/src/utility-types/OmitKeyOf.ts
@@ -1,1 +1,0 @@
-export type OmitKeyOf<TObject extends object, TKey extends keyof TObject> = Omit<TObject, TKey>

--- a/packages/react/src/utility-types/OmitKeyof.test-d.ts
+++ b/packages/react/src/utility-types/OmitKeyof.test-d.ts
@@ -1,0 +1,176 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { OmitKeyof } from './OmitKeyof'
+
+describe('OmitKeyof', () => {
+  it("'s string key type check", () => {
+    type A = {
+      x: string
+      y: number
+    }
+
+    type ExpectedType = {
+      x: string
+    }
+
+    // Bad point
+    // 1. original Omit can use 'z' as type parameter with no type error
+    // 2. original Omit have no auto complete for 2nd type parameter
+    expectTypeOf<Omit<A, 'z' | 'y'>>().toEqualTypeOf<ExpectedType>()
+
+    // Solution
+
+    // 1. strictly
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use 'z' as type parameter with type error because A don't have key 'z'
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        'z' | 'y'
+      >
+    >().toEqualTypeOf<ExpectedType>
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use 'z' as type parameter with type error because A don't have key 'z'
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        'z' | 'y',
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+        'strictly'
+      >
+    >().toEqualTypeOf<ExpectedType>
+
+    // 2. safely
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use 'z' as type parameter type error with strictly parameter or default parameter
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        'z' | 'y'
+      >
+    >().toEqualTypeOf<ExpectedType>
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // With 'safely', OmitKeyof can use 'z' as type parameter like original Omit but This support autocomplete too yet for DX.
+        'z' | 'y',
+        'safely'
+      >
+    >().toEqualTypeOf<ExpectedType>
+  })
+
+  it("'s number key type check", () => {
+    type A = {
+      [1]: string
+      [2]: number
+    }
+
+    type ExpectedType = {
+      [1]: string
+    }
+
+    // Bad point
+    // 1. original Omit can use 3 as type parameter with no type error
+    // 2. original Omit have no auto complete for 2nd type parameter
+    expectTypeOf<Omit<A, 3 | 2>>().toEqualTypeOf<ExpectedType>()
+
+    // Solution
+
+    // 1. strictly
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use 3 as type parameter with type error because A don't have key 3
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        3 | 2
+      >
+    >().toEqualTypeOf<ExpectedType>
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use 3 as type parameter with type error because A don't have key 3
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        3 | 2,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+        'strictly'
+      >
+    >().toEqualTypeOf<ExpectedType>
+
+    // 2. safely
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use 3 as type parameter type error with strictly parameter or default parameter
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        3 | 2
+      >
+    >().toEqualTypeOf<ExpectedType>
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // With 'safely', OmitKeyof can use 3 as type parameter like original Omit but This support autocomplete too yet for DX.
+        3 | 2,
+        'safely'
+      >
+    >().toEqualTypeOf<ExpectedType>
+  })
+
+  it("'s symbol key type check", () => {
+    const symbol1 = Symbol()
+    const symbol2 = Symbol()
+    const symbol3 = Symbol()
+
+    type A = {
+      [symbol1]: string
+      [symbol2]: number
+    }
+
+    type ExpectedType = {
+      [symbol1]: string
+    }
+
+    // Bad point
+    // 1. original Omit can use symbol3 as type parameter with no type error
+    // 2. original Omit have no auto complete for 2nd type parameter
+    expectTypeOf<Omit<A, typeof symbol3 | typeof symbol2>>().toEqualTypeOf<ExpectedType>()
+
+    // Solution
+
+    // 1. strictly
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use symbol3 as type parameter with type error because A don't have key symbol3
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        typeof symbol3 | typeof symbol2
+      >
+    >().toEqualTypeOf<ExpectedType>
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use symbol3 as type parameter with type error because A don't have key symbol3
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        typeof symbol3 | typeof symbol2,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
+        'strictly'
+      >
+    >().toEqualTypeOf<ExpectedType>
+
+    // 2. safely
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // OmitKeyof can't use symbol3 as type parameter type error with strictly parameter or default parameter
+        // @ts-expect-error Type does not satisfy the constraint keyof A
+        typeof symbol3 | typeof symbol2
+      >
+    >().toEqualTypeOf<ExpectedType>
+    expectTypeOf<
+      OmitKeyof<
+        A,
+        // With 'safely', OmitKeyof can use symbol3 as type parameter like original Omit but This support autocomplete too yet for DX.
+        typeof symbol3 | typeof symbol2,
+        'safely'
+      >
+    >().toEqualTypeOf<ExpectedType>
+  })
+})

--- a/packages/react/src/utility-types/OmitKeyof.ts
+++ b/packages/react/src/utility-types/OmitKeyof.ts
@@ -1,0 +1,11 @@
+export type OmitKeyof<
+  TObject,
+  TKey extends TStrictly extends 'safely'
+    ?
+        | keyof TObject
+        | (string & Record<never, never>)
+        | (number & Record<never, never>)
+        | (symbol & Record<never, never>)
+    : keyof TObject,
+  TStrictly extends 'strictly' | 'safely' = 'strictly',
+> = Omit<TObject, TKey>

--- a/packages/react/src/utility-types/index.ts
+++ b/packages/react/src/utility-types/index.ts
@@ -1,4 +1,4 @@
 export type { PropsWithDevMode } from './PropsWithDevMode'
-export type { OmitKeyOf } from './OmitKeyOf'
+export type { OmitKeyof } from './OmitKeyof'
 export type { ConstructorType } from './ConstructorType'
 export type { Nullable } from './Nullable'

--- a/packages/react/src/wrap.tsx
+++ b/packages/react/src/wrap.tsx
@@ -4,7 +4,7 @@ import { Delay } from './Delay'
 import { ErrorBoundary } from './ErrorBoundary'
 import { ErrorBoundaryGroup } from './ErrorBoundaryGroup'
 import { Suspense } from './Suspense'
-import type { OmitKeyOf } from './utility-types'
+import type { OmitKeyof } from './utility-types'
 import type { AsyncBoundaryProps, DelayProps, ErrorBoundaryGroupProps, ErrorBoundaryProps, SuspenseProps } from '.'
 
 type WrapperItem<
@@ -14,7 +14,7 @@ type WrapperItem<
     | typeof ErrorBoundary
     | typeof ErrorBoundaryGroup
     | typeof Delay,
-> = [TWrapperComponent, OmitKeyOf<ComponentProps<TWrapperComponent>, 'children'>]
+> = [TWrapperComponent, OmitKeyof<ComponentProps<TWrapperComponent>, 'children'>]
 
 type Wrapper =
   | WrapperItem<typeof Suspense>
@@ -25,19 +25,19 @@ type Wrapper =
 
 class WrapWithoutCSROnly {
   constructor(private wrappers: Wrapper[]) {}
-  Suspense = (props: OmitKeyOf<ComponentProps<typeof Suspense>, 'children'> = {}) => {
+  Suspense = (props: OmitKeyof<ComponentProps<typeof Suspense>, 'children'> = {}) => {
     this.wrappers.unshift([Suspense, props])
     return this
   }
-  ErrorBoundary = (props: OmitKeyOf<ComponentProps<typeof ErrorBoundary>, 'children'>) => {
+  ErrorBoundary = (props: OmitKeyof<ComponentProps<typeof ErrorBoundary>, 'children'>) => {
     this.wrappers.unshift([ErrorBoundary, props])
     return this
   }
-  ErrorBoundaryGroup = (props: OmitKeyOf<ComponentProps<typeof ErrorBoundaryGroup>, 'children'> = {}) => {
+  ErrorBoundaryGroup = (props: OmitKeyof<ComponentProps<typeof ErrorBoundaryGroup>, 'children'> = {}) => {
     this.wrappers.unshift([ErrorBoundaryGroup, props])
     return this
   }
-  Delay = (props: OmitKeyOf<ComponentProps<typeof Delay>, 'children'> = {}) => {
+  Delay = (props: OmitKeyof<ComponentProps<typeof Delay>, 'children'> = {}) => {
     this.wrappers.unshift([Delay, props])
     return this
   }
@@ -67,29 +67,29 @@ type Wrap = WrapWithoutCSROnly & {
     /**
      * @deprecated Use wrap.Suspense({ clientOnly: true }).on instead
      */
-    CSROnly: (props?: OmitKeyOf<ComponentProps<typeof Suspense.CSROnly>, 'children'>) => Wrap
+    CSROnly: (props?: OmitKeyof<ComponentProps<typeof Suspense.CSROnly>, 'children'>) => Wrap
   }
 }
 
 const createWrap = () => {
   const wrappers: Wrapper[] = []
   const wrap = new WrapWithoutCSROnly(wrappers) as Wrap
-  wrap.Suspense.CSROnly = (props: OmitKeyOf<ComponentProps<typeof Suspense.CSROnly>, 'children'> = {}) => {
+  wrap.Suspense.CSROnly = (props: OmitKeyof<ComponentProps<typeof Suspense.CSROnly>, 'children'> = {}) => {
     wrappers.unshift([Suspense.CSROnly, props])
     return wrap
   }
   return wrap
 }
 
-const wrapSuspense = (props: OmitKeyOf<ComponentProps<typeof Suspense>, 'children'> = {}) =>
+const wrapSuspense = (props: OmitKeyof<ComponentProps<typeof Suspense>, 'children'> = {}) =>
   createWrap().Suspense(props)
-wrapSuspense.CSROnly = (props: OmitKeyOf<ComponentProps<typeof Suspense.CSROnly>, 'children'> = {}) =>
+wrapSuspense.CSROnly = (props: OmitKeyof<ComponentProps<typeof Suspense.CSROnly>, 'children'> = {}) =>
   createWrap().Suspense.CSROnly(props)
-const wrapErrorBoundary = (props: OmitKeyOf<ComponentProps<typeof ErrorBoundary>, 'children'>) =>
+const wrapErrorBoundary = (props: OmitKeyof<ComponentProps<typeof ErrorBoundary>, 'children'>) =>
   createWrap().ErrorBoundary(props)
-const wrapErrorBoundaryGroup = (props: OmitKeyOf<ComponentProps<typeof ErrorBoundaryGroup>, 'children'>) =>
+const wrapErrorBoundaryGroup = (props: OmitKeyof<ComponentProps<typeof ErrorBoundaryGroup>, 'children'>) =>
   createWrap().ErrorBoundaryGroup(props)
-const wrapDelay = (props: OmitKeyOf<ComponentProps<typeof Delay>, 'children'> = {}) => createWrap().Delay(props)
+const wrapDelay = (props: OmitKeyof<ComponentProps<typeof Delay>, 'children'> = {}) => createWrap().Delay(props)
 
 export const wrap = {
   Suspense: wrapSuspense,
@@ -104,7 +104,7 @@ export const wrap = {
 export const withSuspense = Object.assign(
   <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
     component: ComponentType<TProps>,
-    suspenseProps: OmitKeyOf<SuspenseProps, 'children'> = {}
+    suspenseProps: OmitKeyof<SuspenseProps, 'children'> = {}
   ) => wrap.Suspense(suspenseProps).on(component),
   {
     /**
@@ -112,7 +112,7 @@ export const withSuspense = Object.assign(
      */
     CSROnly: <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
       component: ComponentType<TProps>,
-      suspenseProps: OmitKeyOf<SuspenseProps, 'children'> = {}
+      suspenseProps: OmitKeyof<SuspenseProps, 'children'> = {}
     ) => wrap.Suspense.CSROnly(suspenseProps).on(component),
   }
 )
@@ -122,7 +122,7 @@ export const withSuspense = Object.assign(
  */
 export const withErrorBoundary = <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
   component: ComponentType<TProps>,
-  errorBoundaryProps: OmitKeyOf<ErrorBoundaryProps, 'children'>
+  errorBoundaryProps: OmitKeyof<ErrorBoundaryProps, 'children'>
 ) => wrap.ErrorBoundary(errorBoundaryProps).on(component)
 
 /**
@@ -130,7 +130,7 @@ export const withErrorBoundary = <TProps extends ComponentProps<ComponentType> =
  */
 export const withDelay = <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
   component: ComponentType<TProps>,
-  delayProps: OmitKeyOf<DelayProps, 'children'> = {}
+  delayProps: OmitKeyof<DelayProps, 'children'> = {}
 ) => wrap.Delay(delayProps).on(component)
 
 /**
@@ -138,7 +138,7 @@ export const withDelay = <TProps extends ComponentProps<ComponentType> = Record<
  */
 export const withErrorBoundaryGroup = <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
   component: ComponentType<TProps>,
-  errorBoundaryGroupProps: OmitKeyOf<ErrorBoundaryGroupProps, 'children'> = {}
+  errorBoundaryGroupProps: OmitKeyof<ErrorBoundaryGroupProps, 'children'> = {}
 ) => wrap.ErrorBoundaryGroup(errorBoundaryGroupProps).on(component)
 
 /**
@@ -147,7 +147,7 @@ export const withErrorBoundaryGroup = <TProps extends ComponentProps<ComponentTy
 export const withAsyncBoundary = Object.assign(
   <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
     Component: ComponentType<TProps>,
-    asyncBoundaryProps: OmitKeyOf<AsyncBoundaryProps, 'children'>
+    asyncBoundaryProps: OmitKeyof<AsyncBoundaryProps, 'children'>
   ) => {
     const Wrapped = (props: TProps) => (
       <AsyncBoundary {...asyncBoundaryProps}>
@@ -168,7 +168,7 @@ export const withAsyncBoundary = Object.assign(
      */
     CSROnly: <TProps extends ComponentProps<ComponentType> = Record<string, never>>(
       Component: ComponentType<TProps>,
-      asyncBoundaryProps: OmitKeyOf<AsyncBoundaryProps, 'clientOnly' | 'children'>
+      asyncBoundaryProps: OmitKeyof<AsyncBoundaryProps, 'clientOnly' | 'children'>
     ) => {
       const Wrapped = (props: TProps) => (
         <AsyncBoundary {...asyncBoundaryProps} clientOnly>


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about. 
 -->

related with https://github.com/TanStack/query/pull/7139

This change update `OmitKeyof` to validate Omitting keys should be keyof Omitted Object Type

As shown below, the inconvenience of having to manually remove unnecessary fields can be identified early on at the type level with `OmitKeyof`.

### Motivatings
- https://github.com/TanStack/query/pull/6907/files
- https://github.com/TanStack/query/pull/7139#discussion_r1530890783

### Expectation
I made test-d to type-test `OmitKeyof`
- For complex types using `Omit`, I want to reduce the difficulty of library maintenance for it.
    - `OmitKeyof` provide autocomplete by extending keyof TObject
       ![Mar-22-2024 18-12-27](https://github.com/TanStack/query/assets/61593290/3a3b1743-99cc-41bd-9f51-0a24f8973f87)
    - `OmitKeyof` check strictly second type parameter of it by extending keyof TObject
       ![Mar-22-2024 18-13-45](https://github.com/TanStack/query/assets/61593290/4204a036-af4f-4d19-b9fe-3aac39069f90)
    - `OmitKeyof` prevent library contributors make misspell like queryTey or qeuryKey
       ![Mar-22-2024 18-14-35](https://github.com/TanStack/query/assets/61593290/6c7e3ab0-a7bf-420f-a353-292e94297ec2)
- Library users can be supplied with stable types consistently

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
