### PR TITLE
test(react, react-await): separate success & failure descriptions

### DIFF
--- a/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
@@ -5,7 +5,7 @@ const reference1 = { test: 0 }
 const reference2 = { test: 0 }
 
 describe('hasResetKeysChanged', () => {
-  describe('If it is judged to be true', () => {
+  describe('true cases', () => {
     it('should return true if the two arrays have different lengths.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)

--- a/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
@@ -5,49 +5,53 @@ const reference1 = { test: 0 }
 const reference2 = { test: 0 }
 
 describe('hasResetKeysChanged', () => {
-  it('should return true if the two arrays have different lengths.', () => {
-    const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
-    const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)
+  describe('should return true', () => {
+    it('if the two arrays have different lengths.', () => {
+      const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
+      const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)
 
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
+
+    it('if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
+      const array1 = [primitive, primitive + 1]
+      const array2 = [primitive, primitive]
+
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
+
+    it('if the two arrays have same lengths and have all same primitive elements but order is different', () => {
+      const array1 = [primitive, primitive + 1]
+      const array2 = [primitive + 1, primitive]
+
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
+
+    it('if the two arrays have each references elements in index of array have different references', () => {
+      const array1 = [reference1, { test: 2 }]
+      const array2 = [reference1, { test: 2 }]
+
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
   })
 
-  it('should return false if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
-    const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
-    const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)
+  describe('should return false', () => {
+    it('if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
+      const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
+      const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)
 
-    expect(hasResetKeysChanged(array1, array2)).toBe(false)
-  })
+      expect(hasResetKeysChanged(array1, array2)).toBe(false)
+    })
 
-  it('should return true if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
-    const array1 = [primitive, primitive + 1]
-    const array2 = [primitive, primitive]
+    it('if the two arrays have each references elements in index of array have same references', () => {
+      const array1 = [reference1, reference2]
+      const array2 = [reference1, reference2]
 
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
-  })
+      expect(hasResetKeysChanged(array1, array2)).toBe(false)
+    })
 
-  it('should return true if the two arrays have same lengths and have all same primitive elements but order is different', () => {
-    const array1 = [primitive, primitive + 1]
-    const array2 = [primitive + 1, primitive]
-
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
-  })
-
-  it('should return true when two arrays have each references elements in index of array have different references', () => {
-    const array1 = [reference1, { test: 2 }]
-    const array2 = [reference1, { test: 2 }]
-
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
-  })
-
-  it('should return false when two arrays have each references elements in index of array have same references', () => {
-    const array1 = [reference1, reference2]
-    const array2 = [reference1, reference2]
-
-    expect(hasResetKeysChanged(array1, array2)).toBe(false)
-  })
-
-  it('should return false when no arrays as parameters. because of default value', () => {
-    expect(hasResetKeysChanged()).toBe(false)
+    it('if no arrays as parameters. because of default value', () => {
+      expect(hasResetKeysChanged()).toBe(false)
+    })
   })
 })

--- a/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
@@ -35,7 +35,7 @@ describe('hasResetKeysChanged', () => {
     })
   })
 
-  describe('If it is judged to be false', () => {
+  describe('false cases', () => {
     it('should return false if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)

--- a/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react-await/src/utils/hasResetKeysChanged.spec.ts
@@ -5,29 +5,29 @@ const reference1 = { test: 0 }
 const reference2 = { test: 0 }
 
 describe('hasResetKeysChanged', () => {
-  describe('should return true', () => {
-    it('if the two arrays have different lengths.', () => {
+  describe('If it is judged to be true', () => {
+    it('should return true if the two arrays have different lengths.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)
 
       expect(hasResetKeysChanged(array1, array2)).toBe(true)
     })
 
-    it('if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
+    it('should return true if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
       const array1 = [primitive, primitive + 1]
       const array2 = [primitive, primitive]
 
       expect(hasResetKeysChanged(array1, array2)).toBe(true)
     })
 
-    it('if the two arrays have same lengths and have all same primitive elements but order is different', () => {
+    it('should return true if the two arrays have same lengths and have all same primitive elements but order is different', () => {
       const array1 = [primitive, primitive + 1]
       const array2 = [primitive + 1, primitive]
 
       expect(hasResetKeysChanged(array1, array2)).toBe(true)
     })
 
-    it('if the two arrays have each references elements in index of array have different references', () => {
+    it('should return true when two arrays have each references elements in index of array have different references', () => {
       const array1 = [reference1, { test: 2 }]
       const array2 = [reference1, { test: 2 }]
 
@@ -35,22 +35,22 @@ describe('hasResetKeysChanged', () => {
     })
   })
 
-  describe('should return false', () => {
-    it('if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
+  describe('If it is judged to be false', () => {
+    it('should return false if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)
 
       expect(hasResetKeysChanged(array1, array2)).toBe(false)
     })
 
-    it('if the two arrays have each references elements in index of array have same references', () => {
+    it('should return false when two arrays have each references elements in index of array have same references', () => {
       const array1 = [reference1, reference2]
       const array2 = [reference1, reference2]
 
       expect(hasResetKeysChanged(array1, array2)).toBe(false)
     })
 
-    it('if no arrays as parameters. because of default value', () => {
+    it('should return false when no arrays as parameters. because of default value', () => {
       expect(hasResetKeysChanged()).toBe(false)
     })
   })

--- a/packages/react-await/src/utils/isPlainObject.spec.ts
+++ b/packages/react-await/src/utils/isPlainObject.spec.ts
@@ -11,7 +11,7 @@ describe('isPlainObject', () => {
     })
   })
 
-  describe('If it is judged to be false', () => {
+  describe('false cases', () => {
     it('should return false for an array', () => {
       expect(isPlainObject([])).toBe(false)
     })

--- a/packages/react-await/src/utils/isPlainObject.spec.ts
+++ b/packages/react-await/src/utils/isPlainObject.spec.ts
@@ -1,44 +1,48 @@
 import { isPlainObject } from './isPlainObject'
 
 describe('isPlainObject', () => {
-  it('should return true for a plain object', () => {
-    expect(isPlainObject({})).toBe(true)
+  describe('should return true', () => {
+    it('for a plain object', () => {
+      expect(isPlainObject({})).toBe(true)
+    })
+
+    it('for an object without a constructor', () => {
+      expect(isPlainObject(Object.create(null))).toBe(true)
+    })
   })
 
-  it('should return true for an object without a constructor', () => {
-    expect(isPlainObject(Object.create(null))).toBe(true)
-  })
+  describe('should return false', () => {
+    it('for an array', () => {
+      expect(isPlainObject([])).toBe(false)
+    })
 
-  it('should return false for an array', () => {
-    expect(isPlainObject([])).toBe(false)
-  })
+    it('for a null value', () => {
+      expect(isPlainObject(null)).toBe(false)
+    })
 
-  it('should return false for a null value', () => {
-    expect(isPlainObject(null)).toBe(false)
-  })
+    it('for an undefined value', () => {
+      expect(isPlainObject(undefined)).toBe(false)
+    })
 
-  it('should return false for an undefined value', () => {
-    expect(isPlainObject(undefined)).toBe(false)
-  })
-
-  it('should return false for an object instance without an Object-specific method', () => {
-    class Foo {
-      abc: any
-      constructor() {
-        this.abc = {}
+    it('for an object instance without an Object-specific method', () => {
+      class Foo {
+        abc: any
+        constructor() {
+          this.abc = {}
+        }
       }
-    }
-    expect(isPlainObject(new Foo())).toBe(false)
-  })
+      expect(isPlainObject(new Foo())).toBe(false)
+    })
 
-  it('should return false for an object with a custom prototype', () => {
-    function Graph(this: any) {
-      this.vertices = []
-      this.edges = []
-    }
-    Graph.prototype.addVertex = function (v: any) {
-      this.vertices.push(v)
-    }
-    expect(isPlainObject(Object.create(Graph))).toBe(false)
+    it('for an object with a custom prototype', () => {
+      function Graph(this: any) {
+        this.vertices = []
+        this.edges = []
+      }
+      Graph.prototype.addVertex = function (v: any) {
+        this.vertices.push(v)
+      }
+      expect(isPlainObject(Object.create(Graph))).toBe(false)
+    })
   })
 })

--- a/packages/react-await/src/utils/isPlainObject.spec.ts
+++ b/packages/react-await/src/utils/isPlainObject.spec.ts
@@ -1,30 +1,30 @@
 import { isPlainObject } from './isPlainObject'
 
 describe('isPlainObject', () => {
-  describe('should return true', () => {
-    it('for a plain object', () => {
+  describe('If it is judged to be true', () => {
+    it('should return true for a plain object', () => {
       expect(isPlainObject({})).toBe(true)
     })
 
-    it('for an object without a constructor', () => {
+    it('should return true for an object without a constructor', () => {
       expect(isPlainObject(Object.create(null))).toBe(true)
     })
   })
 
-  describe('should return false', () => {
-    it('for an array', () => {
+  describe('If it is judged to be false', () => {
+    it('should return false for an array', () => {
       expect(isPlainObject([])).toBe(false)
     })
 
-    it('for a null value', () => {
+    it('should return false for a null value', () => {
       expect(isPlainObject(null)).toBe(false)
     })
 
-    it('for an undefined value', () => {
+    it('should return false for an undefined value', () => {
       expect(isPlainObject(undefined)).toBe(false)
     })
 
-    it('for an object instance without an Object-specific method', () => {
+    it('should return false for an object instance without an Object-specific method', () => {
       class Foo {
         abc: any
         constructor() {
@@ -34,7 +34,7 @@ describe('isPlainObject', () => {
       expect(isPlainObject(new Foo())).toBe(false)
     })
 
-    it('for an object with a custom prototype', () => {
+    it('should return false for an object with a custom prototype', () => {
       function Graph(this: any) {
         this.vertices = []
         this.edges = []

--- a/packages/react-await/src/utils/isPlainObject.spec.ts
+++ b/packages/react-await/src/utils/isPlainObject.spec.ts
@@ -1,7 +1,7 @@
 import { isPlainObject } from './isPlainObject'
 
 describe('isPlainObject', () => {
-  describe('If it is judged to be true', () => {
+  describe('true cases', () => {
     it('should return true for a plain object', () => {
       expect(isPlainObject({})).toBe(true)
     })

--- a/packages/react/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react/src/utils/hasResetKeysChanged.spec.ts
@@ -5,7 +5,7 @@ const reference1 = { test: 0 }
 const reference2 = { test: 0 }
 
 describe('hasResetKeysChanged', () => {
-  describe('If it is judged to be true', () => {
+  describe('true cases', () => {
     it('should return true if the two arrays have different lengths.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)

--- a/packages/react/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react/src/utils/hasResetKeysChanged.spec.ts
@@ -5,49 +5,53 @@ const reference1 = { test: 0 }
 const reference2 = { test: 0 }
 
 describe('hasResetKeysChanged', () => {
-  it('should return true if the two arrays have different lengths.', () => {
-    const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
-    const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)
+  describe('should return true', () => {
+    it('if the two arrays have different lengths.', () => {
+      const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
+      const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)
 
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
+
+    it('if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
+      const array1 = [primitive, primitive + 1]
+      const array2 = [primitive, primitive]
+
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
+
+    it('if the two arrays have same lengths and have all same primitive elements but order is different', () => {
+      const array1 = [primitive, primitive + 1]
+      const array2 = [primitive + 1, primitive]
+
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
+
+    it('if the two arrays have each references elements in index of array have different references', () => {
+      const array1 = [reference1, { test: 2 }]
+      const array2 = [reference1, { test: 2 }]
+
+      expect(hasResetKeysChanged(array1, array2)).toBe(true)
+    })
   })
 
-  it('should return false if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
-    const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
-    const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)
+  describe('should return false', () => {
+    it('if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
+      const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
+      const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)
 
-    expect(hasResetKeysChanged(array1, array2)).toBe(false)
-  })
+      expect(hasResetKeysChanged(array1, array2)).toBe(false)
+    })
 
-  it('should return true if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
-    const array1 = [primitive, primitive + 1]
-    const array2 = [primitive, primitive]
+    it('if the two arrays have each references elements in index of array have same references', () => {
+      const array1 = [reference1, reference2]
+      const array2 = [reference1, reference2]
 
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
-  })
+      expect(hasResetKeysChanged(array1, array2)).toBe(false)
+    })
 
-  it('should return true if the two arrays have same lengths and have all same primitive elements but order is different', () => {
-    const array1 = [primitive, primitive + 1]
-    const array2 = [primitive + 1, primitive]
-
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
-  })
-
-  it('should return true when two arrays have each references elements in index of array have different references', () => {
-    const array1 = [reference1, { test: 2 }]
-    const array2 = [reference1, { test: 2 }]
-
-    expect(hasResetKeysChanged(array1, array2)).toBe(true)
-  })
-
-  it('should return false when two arrays have each references elements in index of array have same references', () => {
-    const array1 = [reference1, reference2]
-    const array2 = [reference1, reference2]
-
-    expect(hasResetKeysChanged(array1, array2)).toBe(false)
-  })
-
-  it('should return false when no arrays as parameters. because of default value', () => {
-    expect(hasResetKeysChanged()).toBe(false)
+    it('if no arrays as parameters. because of default value', () => {
+      expect(hasResetKeysChanged()).toBe(false)
+    })
   })
 })

--- a/packages/react/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react/src/utils/hasResetKeysChanged.spec.ts
@@ -35,7 +35,7 @@ describe('hasResetKeysChanged', () => {
     })
   })
 
-  describe('If it is judged to be false', () => {
+  describe('false cases', () => {
     it('should return false if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)

--- a/packages/react/src/utils/hasResetKeysChanged.spec.ts
+++ b/packages/react/src/utils/hasResetKeysChanged.spec.ts
@@ -5,29 +5,29 @@ const reference1 = { test: 0 }
 const reference2 = { test: 0 }
 
 describe('hasResetKeysChanged', () => {
-  describe('should return true', () => {
-    it('if the two arrays have different lengths.', () => {
+  describe('If it is judged to be true', () => {
+    it('should return true if the two arrays have different lengths.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 2 }).map((_, index) => primitive + index)
 
       expect(hasResetKeysChanged(array1, array2)).toBe(true)
     })
 
-    it('if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
+    it('should return true if the two arrays have same lengths but at least one primitive element is different in each index of arrays.', () => {
       const array1 = [primitive, primitive + 1]
       const array2 = [primitive, primitive]
 
       expect(hasResetKeysChanged(array1, array2)).toBe(true)
     })
 
-    it('if the two arrays have same lengths and have all same primitive elements but order is different', () => {
+    it('should return true if the two arrays have same lengths and have all same primitive elements but order is different', () => {
       const array1 = [primitive, primitive + 1]
       const array2 = [primitive + 1, primitive]
 
       expect(hasResetKeysChanged(array1, array2)).toBe(true)
     })
 
-    it('if the two arrays have each references elements in index of array have different references', () => {
+    it('should return true when two arrays have each references elements in index of array have different references', () => {
       const array1 = [reference1, { test: 2 }]
       const array2 = [reference1, { test: 2 }]
 
@@ -35,22 +35,22 @@ describe('hasResetKeysChanged', () => {
     })
   })
 
-  describe('should return false', () => {
-    it('if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
+  describe('If it is judged to be false', () => {
+    it('should return false if the two arrays have same lengths and same primitive element in each index of arrays.', () => {
       const array1 = Array.from({ length: 1 }).map((_, index) => primitive + index)
       const array2 = Array.from({ length: 1 }).map((_, index) => primitive + index)
 
       expect(hasResetKeysChanged(array1, array2)).toBe(false)
     })
 
-    it('if the two arrays have each references elements in index of array have same references', () => {
+    it('should return false when two arrays have each references elements in index of array have same references', () => {
       const array1 = [reference1, reference2]
       const array2 = [reference1, reference2]
 
       expect(hasResetKeysChanged(array1, array2)).toBe(false)
     })
 
-    it('if no arrays as parameters. because of default value', () => {
+    it('should return false when no arrays as parameters. because of default value', () => {
       expect(hasResetKeysChanged()).toBe(false)
     })
   })


### PR DESCRIPTION
# Overview

This pull request aims to improve test clarity by **separating success and failure descriptions** into distinct `describe` blocks. I believe this change will enhance readability and maintainability by clearly distinguishing between different test scenarios.

I would appreciate your feedback on this approach. Thank you! :)

Key changes:
- Separate `describe` blocks for success and failure cases.
- Updated test descriptions for clarity.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
