### PR TITLE
fix(react-query): fix SuspenseQuery, SuspenseInfiniteQuery's return type

### DIFF
--- a/.changeset/strange-hats-walk.md
+++ b/.changeset/strange-hats-walk.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react-query": patch
+---
+
+fix(react-query): fix SuspenseQuery, SuspenseInfiniteQuery's return type

--- a/packages/react-query/src/SuspenseInfiniteQuery.test-d.tsx
+++ b/packages/react-query/src/SuspenseInfiniteQuery.test-d.tsx
@@ -86,5 +86,11 @@ describe('<SuspenseInfiniteQuery/>', () => {
         }}
       </SuspenseInfiniteQuery>
     )
+
+    expectTypeOf(
+      <SuspenseInfiniteQuery queryKey={queryKey} queryFn={queryFn}>
+        {() => <></>}
+      </SuspenseInfiniteQuery>
+    ).toEqualTypeOf<JSX.Element>()
   })
 })

--- a/packages/react-query/src/SuspenseInfiniteQuery.tsx
+++ b/packages/react-query/src/SuspenseInfiniteQuery.tsx
@@ -19,4 +19,4 @@ export const SuspenseInfiniteQuery = <
   ...options
 }: UseSuspenseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   children: (query: UseSuspenseInfiniteQueryResult<TData, TError>) => ReactNode
-}) => children(useSuspenseInfiniteQuery(options))
+}) => <>{children(useSuspenseInfiniteQuery(options))}</>

--- a/packages/react-query/src/SuspenseQuery.test-d.tsx
+++ b/packages/react-query/src/SuspenseQuery.test-d.tsx
@@ -78,5 +78,11 @@ describe('<SuspenseQuery/>', () => {
         }}
       </SuspenseQuery>
     )
+
+    expectTypeOf(
+      <SuspenseQuery queryKey={queryKey} queryFn={queryFn}>
+        {() => <></>}
+      </SuspenseQuery>
+    ).toEqualTypeOf<JSX.Element>()
   })
 })

--- a/packages/react-query/src/SuspenseQuery.tsx
+++ b/packages/react-query/src/SuspenseQuery.tsx
@@ -15,4 +15,4 @@ export const SuspenseQuery = <
   ...options
 }: UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
   children: (queryResult: UseSuspenseQueryResult<TData, TError>) => ReactNode
-}) => children(useSuspenseQuery(options))
+}) => <>{children(useSuspenseQuery(options))}</>


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

SuspenseQuery, SuspenseInfiniteQuery's return type should be JSX.Element not just ReactNode

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/suspensive/react/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
