### PR TITLE
fix(react): improved useTimeout and added usePreservedCallback

### DIFF
--- a/.changeset/dull-windows-juggle.md
+++ b/.changeset/dull-windows-juggle.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix(react): improved useTimeout and added usePreservedCallback

--- a/packages/react/src/hooks/usePreservedCallback.spec.ts
+++ b/packages/react/src/hooks/usePreservedCallback.spec.ts
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { usePreservedCallback } from './usePreservedCallback'
+
+describe('usePreservedCallback', () => {
+  it('should preserve the callback function', () => {
+    let counter = 0
+
+    const { result, rerender } = renderHook(({ callback }) => usePreservedCallback(callback), {
+      initialProps: {
+        callback: () => counter,
+      },
+    })
+
+    expect(result.current()).toBe(0)
+
+    counter = 1
+    rerender({ callback: () => counter })
+
+    expect(result.current()).toBe(1)
+  })
+
+  it('should not recreate the callback on each render', () => {
+    const callback = vi.fn()
+    const { result, rerender } = renderHook(() => usePreservedCallback(callback))
+
+    const preservedCallback = result.current
+
+    rerender()
+    expect(result.current).toBe(preservedCallback)
+  })
+
+  it('should call the latest callback', async () => {
+    const callback1 = vi.fn()
+    const callback2 = vi.fn()
+
+    const { result, rerender } = renderHook(({ callback }) => usePreservedCallback(callback), {
+      initialProps: { callback: callback1 },
+    })
+
+    await waitFor(() => {
+      result.current()
+    })
+    expect(callback1).toHaveBeenCalledTimes(1)
+
+    rerender({ callback: callback2 })
+
+    await waitFor(() => {
+      result.current()
+    })
+
+    expect(callback2).toHaveBeenCalledTimes(1)
+    expect(callback1).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/hooks/usePreservedCallback.ts
+++ b/packages/react/src/hooks/usePreservedCallback.ts
@@ -1,0 +1,14 @@
+import { useCallback, useRef } from 'react'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
+
+export const usePreservedCallback = <T extends (...args: unknown[]) => unknown>(callback: T) => {
+  const callbackRef = useRef<T>(callback)
+
+  useIsomorphicLayoutEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  return useCallback((...args: unknown[]) => {
+    return callbackRef.current(...args)
+  }, []) as T
+}

--- a/packages/react/src/hooks/useTimeout.spec.tsx
+++ b/packages/react/src/hooks/useTimeout.spec.tsx
@@ -16,6 +16,25 @@ describe('useTimeout', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
+  it('should call the modified function when the given function is changed', async () => {
+    const timeoutMockFn1 = vi.fn()
+    const timeoutMockFn2 = vi.fn()
+
+    const result = renderHook(({ fn }) => useTimeout(fn, ms('0.1s')), {
+      initialProps: { fn: timeoutMockFn1 },
+    })
+
+    result.rerender({ fn: timeoutMockFn2 })
+
+    expect(timeoutMockFn1).toHaveBeenCalledTimes(0)
+    expect(timeoutMockFn2).toHaveBeenCalledTimes(0)
+
+    await sleep(ms('0.1s'))
+
+    expect(timeoutMockFn1).toHaveBeenCalledTimes(0)
+    expect(timeoutMockFn2).toHaveBeenCalledTimes(1)
+  })
+
   it('should not re-call callback received as argument even if component using this hook is rerendered', async () => {
     const TestComponent = () => {
       const [number, setNumber] = useState(0)

--- a/packages/react/src/hooks/useTimeout.spec.tsx
+++ b/packages/react/src/hooks/useTimeout.spec.tsx
@@ -20,11 +20,11 @@ describe('useTimeout', () => {
     const timeoutMockFn1 = vi.fn()
     const timeoutMockFn2 = vi.fn()
 
-    const result = renderHook(({ fn }) => useTimeout(fn, ms('0.1s')), {
+    const { rerender } = renderHook(({ fn }) => useTimeout(fn, ms('0.1s')), {
       initialProps: { fn: timeoutMockFn1 },
     })
 
-    result.rerender({ fn: timeoutMockFn2 })
+    rerender({ fn: timeoutMockFn2 })
 
     expect(timeoutMockFn1).toHaveBeenCalledTimes(0)
     expect(timeoutMockFn2).toHaveBeenCalledTimes(0)

--- a/packages/react/src/hooks/useTimeout.ts
+++ b/packages/react/src/hooks/useTimeout.ts
@@ -1,15 +1,11 @@
-import { useEffect, useRef } from 'react'
-import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
+import { useEffect } from 'react'
+import { usePreservedCallback } from './usePreservedCallback'
 
 export const useTimeout = (fn: () => void, ms: number) => {
-  const fnRef = useRef(fn)
-
-  useIsomorphicLayoutEffect(() => {
-    fnRef.current = fn
-  }, [fn])
+  const preservedCallback = usePreservedCallback(fn)
 
   useEffect(() => {
-    const id = setTimeout(fnRef.current, ms)
+    const id = setTimeout(preservedCallback, ms)
     return () => clearTimeout(id)
-  }, [ms])
+  }, [preservedCallback, ms])
 }


### PR DESCRIPTION
# Overview

@manudeli Hello! 👋

Currently, `useTimeout` hook is written to call the changed function when the callback function changes.
However, in practice, we're not actually calling the changed function, even if the function changes in the middle.

This is because the only value we currently depend on for `useEffect` is `ms`. 
Adding `ref` to the dependency array doesn't solve this problem because it's not tracked.

These problems can be solved by using hooks like `usePreservedCallback` in `toss/slash`, which can preserve the reference of the callback function, while at the same time ensuring the function is up-to-date. 

- [usePreservedCallback](https://github.com/toss/slash/blob/main/packages/react/react/src/hooks/usePreservedCallback.ts)

Since the `ref` keeps updating during its lifecycle, when calling the function returned by `useCallback`, the latest function will be called by the `closure`.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
