### PR TITLE
docs: change default version

### DIFF
--- a/docs/suspensive.org/src/pages/_meta.en.json
+++ b/docs/suspensive.org/src/pages/_meta.en.json
@@ -18,7 +18,7 @@
   },
   "versions": {
     "type": "menu",
-    "title": "v2",
+    "title": "latest",
     "items": {
       "latest": {
         "title": "latest",

--- a/docs/suspensive.org/src/pages/_meta.ko.json
+++ b/docs/suspensive.org/src/pages/_meta.ko.json
@@ -18,7 +18,7 @@
   },
   "versions": {
     "type": "menu",
-    "title": "v2",
+    "title": "latest",
     "items": {
       "latest": {
         "title": "latest",


### PR DESCRIPTION
# Overview

- The default is v2, so the issue appears to be v2 even in the `https://suspensive.org`.

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
