### PR TITLE
feat(jotai): add jsdoc to jotai component

### DIFF
--- a/.changeset/cool-baboons-enjoy.md
+++ b/.changeset/cool-baboons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/jotai": patch
+---
+
+feat(jotai): add jsdoc to jotai component

--- a/packages/jotai/src/Atom.tsx
+++ b/packages/jotai/src/Atom.tsx
@@ -19,6 +19,12 @@ type UseAtomProps<TAtom extends Parameters<typeof useAtom>[0]> = {
   options?: Parameters<typeof useAtom>[1]
 }
 
+/**
+ * This hook is wrapping `useAtom` hook from jotai.
+ *
+ * The Atom component provides an interface similar to Jotai's `useAtom` hook as props, allowing declarative usage.
+ * @see {@link https://suspensive.org/docs/jotai/Atom}
+ */
 export function Atom<TValue, TArgs extends unknown[], TResult>({
   children,
   atom,

--- a/packages/jotai/src/Atom.tsx
+++ b/packages/jotai/src/Atom.tsx
@@ -24,6 +24,24 @@ type UseAtomProps<TAtom extends Parameters<typeof useAtom>[0]> = {
  *
  * The Atom component provides an interface similar to Jotai's `useAtom` hook as props, allowing declarative usage.
  * @see {@link https://suspensive.org/docs/jotai/Atom}
+ * @example
+ * ```jsx
+ * import { Atom } from '@suspensive/jotai'
+ * import { atom } from "jotai";
+ *
+ * const countAtom = atom(1);
+ *
+ * const Example = () => (
+ *   <Atom atom={countAtom}>
+ *     {([count, setCount]) => (
+ *       <>
+ *         <div>count: {count}</div>
+ *         <button onClick={() => setCount(count + 1)}>+1</button>
+ *       </>
+ *     )}
+ *   </Atom>
+ * )
+ * ```
  */
 export function Atom<TValue, TArgs extends unknown[], TResult>({
   children,

--- a/packages/jotai/src/AtomValue.tsx
+++ b/packages/jotai/src/AtomValue.tsx
@@ -12,6 +12,21 @@ type UseAtomValueProps<TAtom extends Parameters<typeof useAtomValue>[0]> = {
  *
  * The AtomValue component provides an interface similar to Jotai's `useAtomValue` hook as props, allowing declarative usage.
  * @see {@link https://suspensive.org/docs/jotai/AtomValue}
+ * @example
+ * ```jsx
+ * import { AtomValue } from '@suspensive/jotai'
+ * import { atom } from "jotai";
+ *
+ * const countAtom = atom(1);
+ *
+ * const Example = () => (
+ *   <AtomValue atom={countAtom}>
+ *     {(count) => (
+ *       <>count: {count}</>
+ *     )}
+ *   </AtomValue>
+ * )
+ * ```
  */
 export function AtomValue<TValue>({
   children,

--- a/packages/jotai/src/AtomValue.tsx
+++ b/packages/jotai/src/AtomValue.tsx
@@ -7,6 +7,12 @@ type UseAtomValueProps<TAtom extends Parameters<typeof useAtomValue>[0]> = {
   options?: Parameters<typeof useAtomValue>[1]
 }
 
+/**
+ * This hook is wrapping `useAtomValue` hook from jotai.
+ *
+ * The AtomValue component provides an interface similar to Jotai's `useAtomValue` hook as props, allowing declarative usage.
+ * @see {@link https://suspensive.org/docs/jotai/AtomValue}
+ */
 export function AtomValue<TValue>({
   children,
   atom,

--- a/packages/jotai/src/SetAtom.tsx
+++ b/packages/jotai/src/SetAtom.tsx
@@ -7,6 +7,12 @@ type UseSetAtomProps<TAtom> = {
   options?: Parameters<typeof useSetAtom>[1]
 }
 
+/**
+ * This Component is wrapping `useSetAtom` of jotai
+ *
+ * The SetAtom component provides an interface similar to Jotai's useSetAtom hook as props, allowing declarative usage.
+ * @see {@link https://suspensive.org/docs/jotai/SetAtom}
+ */
 export function SetAtom<TValue, TArgs extends unknown[], TResult>({
   atom,
   options,

--- a/packages/jotai/src/SetAtom.tsx
+++ b/packages/jotai/src/SetAtom.tsx
@@ -10,8 +10,26 @@ type UseSetAtomProps<TAtom> = {
 /**
  * This Component is wrapping `useSetAtom` of jotai
  *
- * The SetAtom component provides an interface similar to Jotai's useSetAtom hook as props, allowing declarative usage.
+ * The SetAtom component provides an interface similar to Jotai's `useSetAtom` hook as props, allowing declarative usage.
  * @see {@link https://suspensive.org/docs/jotai/SetAtom}
+ * @example
+ * ```jsx
+ * import { SetAtom } from '@suspensive/jotai'
+ * import { atom } from "jotai";
+ *
+ * const switchAtom = atom(false)
+ *
+ * const Example = () => (
+ *   <SetAtom atom={switchAtom}>
+ *     {(setCount) => (
+ *       <>
+ *         <button onClick={() => setCount(true)}>Set True</button>
+ *         <button onClick={() => setCount(false)}>Set False</button>
+ *       </>
+ *     )}
+ *   </SetAtom>
+ * )
+ * ```
  */
 export function SetAtom<TValue, TArgs extends unknown[], TResult>({
   atom,


### PR DESCRIPTION
# Overview

| Atom | 
| --- |
|<img width="790" alt="image" src="https://github.com/user-attachments/assets/16f31c8a-1f47-4eba-a5cc-32837e146b2d">|

| AtomValue |
| --- |
|<img width="789" alt="image" src="https://github.com/user-attachments/assets/ec2dfdd2-bd28-4037-8369-00eec2289268">|

| SetAtom |
| --- |
|<img width="792" alt="image" src="https://github.com/user-attachments/assets/ea38930c-ad7b-47cb-a1d0-e7a4d6e4752f">|


## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
