### PR TITLE
fix(react-query): update tanstack query as optional peerDependency

### DIFF
--- a/.changeset/wet-rivers-confess.md
+++ b/.changeset/wet-rivers-confess.md
@@ -1,0 +1,6 @@
+---
+"@suspensive/react-query-4": patch
+"@suspensive/react-query-5": patch
+---
+
+fix(react-query): update tanstack query as optional peerDependency

--- a/knip.json
+++ b/knip.json
@@ -16,8 +16,11 @@
       "ignoreDependencies": ["sharp"],
       "entry": ["src/**/*.{ts,tsx,mdx}"]
     },
-    "packages/react-query-*": {
-      "ignoreDependencies": ["@suspensive/react"]
+    "packages/react-query-4": {
+      "ignoreDependencies": ["@suspensive/react", "@tanstack/react-query"]
+    },
+    "packages/react-query-5": {
+      "ignoreDependencies": ["@suspensive/react", "@tanstack/react-query"]
     },
     "packages/react-native": {
       "ignoreDependencies": ["expo", "ts-node"],

--- a/packages/react-query-4/package.json
+++ b/packages/react-query-4/package.json
@@ -69,6 +69,9 @@
   "peerDependenciesMeta": {
     "@suspensive/react": {
       "optional": true
+    },
+    "@tanstack/react-query": {
+      "optional": true
     }
   },
   "publishConfig": {

--- a/packages/react-query-5/package.json
+++ b/packages/react-query-5/package.json
@@ -69,6 +69,9 @@
   "peerDependenciesMeta": {
     "@suspensive/react": {
       "optional": true
+    },
+    "@tanstack/react-query": {
+      "optional": true
     }
   },
   "publishConfig": {


### PR DESCRIPTION
Thanks to @ha1fstack!

User can use TanStack Query only v4 or v5 not both. so we need to make them as optional peerDependency! @ha1fstack catch this error and report it. So much thanks!