### PR TITLE
fix(suspensive.org): fix `v2` place in the logo

### DIFF
--- a/docs/suspensive.org/src/components/HomePage.tsx
+++ b/docs/suspensive.org/src/components/HomePage.tsx
@@ -21,7 +21,7 @@ export const HomePage = ({
         <Image src="/img/logo_background_star.png" alt="Suspensive with star" width={400} height={241} />
         <div className="flex flex-col items-center gap-4">
           <div className="relative text-5xl font-bold">
-            <span>{title}</span> <span className="absolute right-0 text-sm">v{version}</span>
+            <span>{title}</span> <span className="absolute text-sm">v{version}</span>
           </div>
           <p className="text-3xl">{description}</p>
         </div>

--- a/docs/suspensive.org/theme.config.tsx
+++ b/docs/suspensive.org/theme.config.tsx
@@ -34,7 +34,7 @@ const config: DocsThemeConfig = {
         <Image src="/img/logo_dark.png" width={34} height={34} alt="suspensive logo" />
         <div className="relative">
           <strong>Suspensive</strong>
-          <span className="absolute right-0 text-[8px]">v2</span>
+          <span className="absolute text-[8px]">v2</span>
         </div>
       </div>
     )


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Quick little UI bug I found. Fixed by removing `right-0`. Thanks!

### AS-IS
<img width="855" alt="Captura de pantalla 2024-09-25 a las 12 02 34 p  m" src="https://github.com/user-attachments/assets/35bed338-7b43-443c-ad71-ce826f22e194">

### TO-BE
<img width="845" alt="Captura de pantalla 2024-09-25 a las 12 04 24 p  m" src="https://github.com/user-attachments/assets/3573678d-9d4e-424f-be29-58bde250a121">

## PR Checklist

- [✅] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
