### PR TITLE
fix(react): re-throw SuspensiveError before rerender

### DIFF
--- a/.changeset/healthy-cars-decide.md
+++ b/.changeset/healthy-cars-decide.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react": patch
+---
+
+fix(react): re-throw SuspensiveError before rerender

--- a/packages/react/src/ErrorBoundary.spec.tsx
+++ b/packages/react/src/ErrorBoundary.spec.tsx
@@ -376,6 +376,14 @@ describe('useErrorBoundary', () => {
     ).toBeInTheDocument()
     expect(() =>
       render(
+        createElement(() => {
+          useErrorBoundary()
+          return <></>
+        })
+      )
+    ).toThrow(SuspensiveError)
+    expect(() =>
+      render(
         <ErrorBoundary
           fallback={() => {
             useErrorBoundary()
@@ -423,9 +431,15 @@ describe('useErrorBoundaryFallbackProps', () => {
   })
 
   it('should guarantee hook calling position is in fallback of ErrorBoundary', () => {
+    const inFallback = vi.fn()
     expect(() =>
       render(
-        <ErrorBoundary fallback={(props) => <>{props.error.message}</>}>
+        <ErrorBoundary
+          fallback={(props) => {
+            inFallback()
+            return <>{props.error.message}</>
+          }}
+        >
           {createElement(() => {
             useErrorBoundaryFallbackProps()
             return <></>
@@ -433,6 +447,7 @@ describe('useErrorBoundaryFallbackProps', () => {
         </ErrorBoundary>
       )
     ).toThrow(SuspensiveError)
+    expect(inFallback).toHaveBeenCalledTimes(0)
   })
   it('should be prevented to be called outside fallback of ErrorBoundary', () => {
     expect(() =>
@@ -445,9 +460,15 @@ describe('useErrorBoundaryFallbackProps', () => {
     ).toThrow(SuspensiveError)
   })
   it("should be prevented to be called in children of ErrorBoundary (ErrorBoundary shouldn't catch SuspensiveError)", () => {
+    const inFallback = vi.fn()
     expect(() =>
       render(
-        <ErrorBoundary fallback={(props) => <>{props.error.message}</>}>
+        <ErrorBoundary
+          fallback={(props) => {
+            inFallback()
+            return <>{props.error.message}</>
+          }}
+        >
           {createElement(() => {
             useErrorBoundaryFallbackProps()
             return <></>
@@ -455,5 +476,6 @@ describe('useErrorBoundaryFallbackProps', () => {
         </ErrorBoundary>
       )
     ).toThrow(SuspensiveError)
+    expect(inFallback).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -115,9 +115,6 @@ class BaseErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    if (error instanceof SuspensiveError) {
-      throw error
-    }
     this.props.onError?.(error, info)
   }
 
@@ -133,6 +130,9 @@ class BaseErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
     let childrenOrFallback = children
 
     if (isError) {
+      if (error instanceof SuspensiveError) {
+        throw error
+      }
       const isCatch = Array.isArray(shouldCatch)
         ? shouldCatch.some((shouldCatch) => checkErrorBoundary(shouldCatch, error))
         : checkErrorBoundary(shouldCatch, error)


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

componentDidCatch will be triggered after render. so I move code re-throwing SuspensiveError from componentDidCatch to render

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
