### PR TITLE
ci(.github/actions/pnpm-setup-node): remove 'cache-dependency-path' option in 'actions/setup-node'

### DIFF
--- a/.github/actions/pnpm-setup-node/action.yml
+++ b/.github/actions/pnpm-setup-node/action.yml
@@ -6,6 +6,5 @@ runs:
     - uses: pnpm/action-setup@v4
     - uses: actions/setup-node@v4
       with:
-        cache: 'pnpm'
-        cache-dependency-path: 'pnpm-lock.yaml'
         node-version-file: '.nvmrc'
+        cache: 'pnpm'


### PR DESCRIPTION
# Overview

* If `cache` is configured to `pnpm`, the action defaults to search for the dependency file (`pnpm-lock.yaml`) in the repository root. It's duplicated configuration, so we can remove it.
  * https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data
  * https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
