### PR TITLE
fix: add contents write permission to release workflow

### DIFF
--- a/.changeset/busy-deer-attack.md
+++ b/.changeset/busy-deer-attack.md
@@ -1,0 +1,5 @@
+---
+'@suspensive/react': patch
+---
+
+fix: add contents write permission to release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-setup-node


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Adds `contents: write` permission to release workflow for managing repository content.

P.S. Sorry for the frequent PRs lately. 🙏


## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
