### PR TITLE
test(react-dom/observe): add test for fallback when 'IntersectionObserver' is 'undefined'

### DIFF
--- a/packages/react-dom/src/utils/observe.spec.ts
+++ b/packages/react-dom/src/utils/observe.spec.ts
@@ -64,3 +64,32 @@ it('should convert options to id', () => {
     })
   ).toMatchInlineSnapshot(`"threshold_0,0.5,1"`)
 })
+
+it('should use fallback intersectionRatio when IntersectionObserver is undefined', () => {
+  const element = document.createElement('div')
+  const cb = vi.fn()
+  const originalObserver = window.IntersectionObserver
+
+  Object.defineProperty(window, 'IntersectionObserver', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  })
+
+  const unmount = observe(element, cb, { threshold: 0.75 }, true)
+
+  expect(cb).toHaveBeenCalledWith(
+    true,
+    expect.objectContaining({
+      intersectionRatio: 0.75,
+    })
+  )
+
+  unmount()
+
+  Object.defineProperty(window, 'IntersectionObserver', {
+    configurable: true,
+    writable: true,
+    value: originalObserver,
+  })
+})


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

* relate #1464 

## before

<img width="615" alt="image" src="https://github.com/user-attachments/assets/f1cef368-13f5-4db0-9153-4cf2a1fad054" />

## after

<img width="622" alt="image" src="https://github.com/user-attachments/assets/d17dff58-66ac-4429-a1b1-a440f0ace456" />

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
