### PR TITLE
chore: hoist prettier plugin deps to root

### DIFF
--- a/docs/suspensive.org/package.json
+++ b/docs/suspensive.org/package.json
@@ -49,7 +49,6 @@
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
     "pagefind": "^1.3.0",
-    "prettier-plugin-tailwindcss": "catalog:",
     "tailwindcss": "catalog:"
   }
 }

--- a/examples/next-streaming-react-query/package.json
+++ b/examples/next-streaming-react-query/package.json
@@ -28,7 +28,6 @@
     "@tailwindcss/postcss": "catalog:",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "prettier-plugin-tailwindcss": "catalog:",
     "tailwindcss": "catalog:"
   }
 }

--- a/examples/visualization/package.json
+++ b/examples/visualization/package.json
@@ -33,7 +33,6 @@
     "@tailwindcss/postcss": "catalog:",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "prettier-plugin-tailwindcss": "catalog:",
     "tailwindcss": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "packlint": "^0.2.4",
     "playwright": "^1.52.0",
     "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.13",
     "publint": "^0.3.12",
     "rimraf": "^6.0.1",
     "sherif": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ catalogs:
     next:
       specifier: ^15.3.3
       version: 15.3.3
-    prettier-plugin-tailwindcss:
-      specifier: ^0.6.13
-      version: 0.6.13
     sharp:
       specifier: ^0.34.2
       version: 0.34.2
@@ -165,6 +162,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.13
+        version: 0.6.13(prettier@3.5.3)
       publint:
         specifier: ^0.3.12
         version: 0.3.12
@@ -318,9 +318,6 @@ importers:
       pagefind:
         specifier: ^1.3.0
         version: 1.3.0
-      prettier-plugin-tailwindcss:
-        specifier: 'catalog:'
-        version: 0.6.13(prettier@3.5.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.8
@@ -367,9 +364,6 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.1.2(@types/react@19.1.6)
-      prettier-plugin-tailwindcss:
-        specifier: 'catalog:'
-        version: 0.6.13(prettier@3.5.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.8
@@ -421,7 +415,7 @@ importers:
         version: 29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3))
       jest-expo:
         specifier: catalog:react19
-        version: 52.0.2(@babel/core@7.27.1)(expo@52.0.24(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@4.0.0(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)))(graphql@16.9.0)(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(jest@29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3)))(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)(webpack@5.96.1(esbuild@0.25.0))
+        version: 52.0.2(@babel/core@7.27.1)(expo@52.0.24(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@4.0.0(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)))(graphql@16.9.0)(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(jest@29.7.0(@types/node@22.14.1))(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)(webpack@5.96.1(esbuild@0.25.0))
       react-test-renderer:
         specifier: 19.0.0
         version: 19.0.0(react@19.1.0)
@@ -486,9 +480,6 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.1.2(@types/react@19.1.6)
-      prettier-plugin-tailwindcss:
-        specifier: 'catalog:'
-        version: 0.6.13(prettier@3.5.3)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.8
@@ -661,7 +652,7 @@ importers:
         version: 29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3))
       jest-expo:
         specifier: catalog:react19
-        version: 52.0.2(@babel/core@7.27.1)(expo@52.0.24(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@4.0.0(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)))(graphql@16.9.0)(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(jest@29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3)))(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)(webpack@5.96.1(esbuild@0.25.0))
+        version: 52.0.2(@babel/core@7.27.1)(expo@52.0.24(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@4.0.0(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)))(graphql@16.9.0)(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(jest@29.7.0(@types/node@22.14.1))(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)(webpack@5.96.1(esbuild@0.25.0))
       react:
         specifier: catalog:react19
         version: 19.1.0
@@ -18455,7 +18446,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@52.0.2(@babel/core@7.27.1)(expo@52.0.24(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@4.0.0(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)))(graphql@16.9.0)(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(jest@29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3)))(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)(webpack@5.96.1(esbuild@0.25.0)):
+  jest-expo@52.0.2(@babel/core@7.27.1)(expo@52.0.24(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@expo/metro-runtime@4.0.0(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)))(graphql@16.9.0)(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0))(jest@29.7.0(@types/node@22.14.1))(react-dom@19.1.0(react@19.1.0))(react-native@0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0))(react@19.1.0)(webpack@5.96.1(esbuild@0.25.0)):
     dependencies:
       '@expo/config': 10.0.7
       '@expo/json-file': 9.0.0
@@ -18468,7 +18459,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3)))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.14.1))
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.76.6(@babel/core@7.27.1)(@babel/preset-env@7.26.0(@babel/core@7.27.1))(@types/react@19.1.6)(react@19.1.0)
@@ -18663,7 +18654,7 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3))):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.14.1)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,55 +1,54 @@
 packages:
-  - "configs/*"
-  - "docs/*"
-  - "examples/*"
-  - "packages/*"
+  - 'configs/*'
+  - 'docs/*'
+  - 'examples/*'
+  - 'packages/*'
 
 catalog:
-  "babel-jest": "^29.7.0"
-  "jest": "^29.7.0"
+  'babel-jest': '^29.7.0'
+  'jest': '^29.7.0'
   # next
-  "next": "^15.3.3"
-  "@next/eslint-plugin-next": "^15.3.3"
-  "@next/third-parties": "^15.3.3"
-  "sharp": "^0.34.2"
+  'next': '^15.3.3'
+  '@next/eslint-plugin-next': '^15.3.3'
+  '@next/third-parties': '^15.3.3'
+  'sharp': '^0.34.2'
 
   # tailwindcss
-  "prettier-plugin-tailwindcss": "^0.6.13"
-  "@tailwindcss/postcss": "^4.1.8"
-  "tailwindcss": "^4.1.8"
-  "clsx": "^2.1.1"
+  '@tailwindcss/postcss': '^4.1.8'
+  'tailwindcss': '^4.1.8'
+  'clsx': '^2.1.1'
 
 catalogs:
   react18:
     # react
-    "react": "18.3.1"
-    "@types/react": "18.3.12"
+    'react': '18.3.1'
+    '@types/react': '18.3.12'
     # react-dom
-    "react-dom": "18.3.1"
-    "@types/react-dom": "18.3.1"
+    'react-dom': '18.3.1'
+    '@types/react-dom': '18.3.1'
 
   react19:
     # react
-    "react": "^19.1.0"
-    "@types/react": "^19.1.6"
+    'react': '^19.1.0'
+    '@types/react': '^19.1.6'
     # react-dom
-    "react-dom": "^19.1.0"
-    "@types/react-dom": "^19.1.2"
+    'react-dom': '^19.1.0'
+    '@types/react-dom': '^19.1.2'
     # react-native
-    "@react-navigation/native": "^7.0.14"
-    "expo": "^52.0.24"
-    "expo-router": "^4.0.16"
-    "react-native": "^0.76.6"
-    "react-native-web": "^0.19.13"
-    "jest-expo": "^52.0.2"
-    "@testing-library/react-native": "^12.9.0"
+    '@react-navigation/native': '^7.0.14'
+    'expo': '^52.0.24'
+    'expo-router': '^4.0.16'
+    'react-native': '^0.76.6'
+    'react-native-web': '^0.19.13'
+    'jest-expo': '^52.0.2'
+    '@testing-library/react-native': '^12.9.0'
 
   # react-query
   react-query4:
-    "@tanstack/react-query": "4.40.0"
-    "@tanstack/react-query-devtools": "4.40.0"
+    '@tanstack/react-query': '4.40.0'
+    '@tanstack/react-query-devtools': '4.40.0'
 
   react-query5:
-    "@tanstack/react-query": "^5.79.0"
-    "@tanstack/react-query-devtools": "^5.79.0"
-    "@tanstack/react-query-next-experimental": "^5.79.0"
+    '@tanstack/react-query': '^5.79.0'
+    '@tanstack/react-query-devtools': '^5.79.0'
+    '@tanstack/react-query-next-experimental': '^5.79.0'


### PR DESCRIPTION
# Overview

 > public-hoist-pattern: nothing is hoisted by default. Packages containing eslint or prettier in their name are no longer hoisted to the root of node_modules. Related Issue: https://github.com/pnpm/pnpm/issues/8378
https://github.com/pnpm/pnpm/releases/tag/v10.0.0

![image](https://github.com/user-attachments/assets/56fe2577-4141-46c5-b31e-df165458c459)

In pnpm v.10 major changes, the `public-hoist-pattern` has been modified.

Dependencies with names like `eslint`, `prettier`, `eslint-config-*`, and `@eslint/eslint-plugin-*` are no longer automatically placed in the root `node_modules` directory; instead, they are located under each package's `node_modules`.

As a result, the format script fails. Install the prettier plugin in the root.



## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
