### PR TITLE
docs: correct typo `postsInifiniteQuery` to `postsInfiniteQuery` in example code

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react-query/usePrefetchInfiniteQuery.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-query/usePrefetchInfiniteQuery.mdx
@@ -24,7 +24,7 @@ const PostsPage = ({ postId }) => {
 }
 
 export const Posts = () => {
-  const postsInifiniteQuery = useSuspenseInfiniteQuery({
+  const postsInfiniteQuery = useSuspenseInfiniteQuery({
     queryKey: ['posts'],
     queryFn: () => getPosts(),
   })

--- a/docs/suspensive.org/src/content/ko/docs/react-query/usePrefetchInfiniteQuery.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/usePrefetchInfiniteQuery.mdx
@@ -24,7 +24,7 @@ const PostsPage = ({ postId }) => {
 }
 
 export const Posts = () => {
-  const postsInifiniteQuery = useSuspenseInfiniteQuery({
+  const postsInfiniteQuery = useSuspenseInfiniteQuery({
     queryKey: ['posts'],
     queryFn: () => getPosts(),
   })


### PR DESCRIPTION
# Overview

This PR fixes a typo in the example code where `postsInifiniteQuery` was misspelled. It is corrected to `postsInfiniteQuery`, improving code clarity and correctness in the documentation.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
