### PR TITLE
docs: fix User type and clean up extra spaces in usage example

### DIFF
--- a/docs/suspensive.org/src/content/en/docs/react-query/SuspenseQueries.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-query/SuspenseQueries.mdx
@@ -149,13 +149,13 @@ export type User = {
       lat: string
       lng: string
     }
-    phone: string
-    website: string
-    company: {
-      name: string
-      catchPhrase: string
-      bs: string
-    }
+  }
+  phone: string
+  website: string
+  company: {
+    name: string
+    catchPhrase: string
+    bs: string
   }
 }
 

--- a/docs/suspensive.org/src/content/en/docs/react-query/SuspenseQuery.mdx
+++ b/docs/suspensive.org/src/content/en/docs/react-query/SuspenseQuery.mdx
@@ -177,13 +177,13 @@ export type User = {
       lat: string
       lng: string
     }
-    phone: string
-    website: string
-    company: {
-      name: string
-      catchPhrase: string
-      bs: string
-    }
+  }
+  phone: string
+  website: string
+  company: {
+    name: string
+    catchPhrase: string
+    bs: string
   }
 }
 
@@ -218,9 +218,9 @@ import { PostList } from './components/PostList'
 const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback={'loading...'}>
-      <UserInfo userId={userId} />{' '}
+      <UserInfo userId={userId} />
       {/* It is difficult to predict whether a suspension will occur internally. */}
-      <PostList userId={userId} />{' '}
+      <PostList userId={userId} />
       {/* It is difficult to predict whether a suspension will occur internally. */}
     </Suspense>
   </ErrorBoundary>

--- a/docs/suspensive.org/src/content/ko/docs/react-query/SuspenseQueries.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/SuspenseQueries.mdx
@@ -149,13 +149,13 @@ export type User = {
       lat: string
       lng: string
     }
-    phone: string
-    website: string
-    company: {
-      name: string
-      catchPhrase: string
-      bs: string
-    }
+  }
+  phone: string
+  website: string
+  company: {
+    name: string
+    catchPhrase: string
+    bs: string
   }
 }
 

--- a/docs/suspensive.org/src/content/ko/docs/react-query/SuspenseQuery.mdx
+++ b/docs/suspensive.org/src/content/ko/docs/react-query/SuspenseQuery.mdx
@@ -177,13 +177,13 @@ export type User = {
       lat: string
       lng: string
     }
-    phone: string
-    website: string
-    company: {
-      name: string
-      catchPhrase: string
-      bs: string
-    }
+  }
+  phone: string
+  website: string
+  company: {
+    name: string
+    catchPhrase: string
+    bs: string
   }
 }
 
@@ -218,9 +218,9 @@ import { PostList } from './components/PostList'
 const PostsPage = ({ userId }) => (
   <ErrorBoundary fallback={({ error }) => <>{error.message}</>}>
     <Suspense fallback={'loading...'}>
-      <UserInfo userId={userId} />{' '}
+      <UserInfo userId={userId} />
       {/* 내부적으로 Suspense를 발생할 지 예상하기 어렵습니다. */}
-      <PostList userId={userId} />{' '}
+      <PostList userId={userId} />
       {/* 내부적으로 Suspense를 발생할 지 예상하기 어렵습니다. */}
     </Suspense>
   </ErrorBoundary>


### PR DESCRIPTION
# Overview

- Refined the `User` type by moving `phone`, `website`, and `company` fields outside the `address` object for better clarity and usage.
```tsx
type User = {
  id: number
  name: string
  username: string
  email: string
  address: {
    street: string
    suite: string
    city: string
    zipcode: string
    geo: {
      lat: string
      lng: string
    }
  }
  // Change out of the address attribute
  phone: string
  website: string
  company: {
    name: string
    catchPhrase: string
    bs: string
  }
}

export const UserProfile = (props: User) => {
  return (
    <div style={{ padding: '16px' }}>
      <h1>{props.name}</h1>
      <p>{props.email}</p>
      <p>{props.phone}</p>
    </div>
  )
}
```
- Removed unnecessary trailing spaces (`{' '}`) after `<UserInfo userId={userId} />` in example code to improve code readability.

These changes improve type correctness and example clarity in documentation.

## PR Checklist

- [X] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
