### PR TITLE
ci(.github/workflows): add repository checks to prevent fork execution

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   broken-link-checker:
+    if: github.repository == 'toss/suspensive'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     name: Build
+    if: github.repository == 'toss/suspensive'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -32,6 +33,7 @@ jobs:
           path: ./graph
 
   deploy:
+    if: github.repository == 'toss/suspensive'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'toss/suspensive'
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

 - Add `if: github.repository == 'toss/suspensive'` conditions to workflows that should only run in the origin repository
 - Prevents unnecessary execution in forked repositories for:
    - `broken-link-checker.yml` - scheduled link checking
    - `graph.yml` - GitHub Pages deployment
    - `release.yml` - NPM package publishing

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
