### PR TITLE
fix(react): update @suspensive/react description to use plural form

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@suspensive/react",
   "version": "3.17.2",
-  "description": "Suspensive interface for react",
+  "description": "Suspensive interfaces for react",
   "keywords": [
     "suspensive",
     "react"


### PR DESCRIPTION
Change "Suspensive interface" to "Suspensive interfaces" to maintain consistency with other packages

# Overview

## Description
This PR updates the package description in `@suspensive/react` to use the plural form "interfaces" to maintain consistency with other Suspensive packages.

## Changes
- Changed description from "Suspensive interface for react" to "Suspensive interfaces for react" in `packages/react/package.json`

## Motivation
All other Suspensive packages (`@suspensive/react-query`, `@suspensive/jotai`, etc.) use the plural form "Suspensive interfaces" in their descriptions. This change ensures consistency across all package descriptions in the monorepo.

## Related Packages
The following packages already use the plural form:
- `@suspensive/react-query`: "Suspensive interfaces for @tanstack/react-query"
- `@suspensive/jotai`: "Suspensive interfaces for jotai"
- `@suspensive/react-dom`: "Suspensive interfaces for react-dom"

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
