### PR TITLE
docs(react-dom): fix grammar in observe utility comment

### DIFF
--- a/packages/react-dom/src/utils/observe.ts
+++ b/packages/react-dom/src/utils/observe.ts
@@ -120,7 +120,7 @@ export function observe(
     }
 
     if (elements.size === 0) {
-      // No more elements are being observer by this instance, so destroy it
+      // No more elements are being observed by this instance, so destroy it
       observer.disconnect()
       observerMap.delete(id)
     }


### PR DESCRIPTION
# Overview

Fixed a grammatical error in a comment within the `observe.ts` utility file.
Changed "being observer" to "being observed" for proper passive voice grammar.

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
