### PR TITLE
fix(react-query): cancel timed-out hydration queries by predicate

### DIFF
--- a/packages/react-query-4/src/QueriesHydration.spec.tsx
+++ b/packages/react-query-4/src/QueriesHydration.spec.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider, dehydrate, infiniteQueryOptions } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, dehydrate, hashQueryKey, infiniteQueryOptions } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ComponentProps, ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -354,6 +354,7 @@ describe('<QueriesHydration/>', () => {
 
   it('should timeout when query takes longer than the timeout', async () => {
     const serverQueryClient = new QueryClient()
+    const cancelQueriesSpy = vi.spyOn(serverQueryClient, 'cancelQueries')
     const timeoutMs = 100
     const queryDelayMs = 200
     const mockQueryFn = vi
@@ -381,11 +382,85 @@ describe('<QueriesHydration/>', () => {
     })
 
     expect(mockQueryFn).toHaveBeenCalledTimes(1)
+    expect(cancelQueriesSpy).toHaveBeenCalledTimes(1)
+    const timeoutCancelFilters = cancelQueriesSpy.mock.calls[0]?.[0] as
+      | { predicate?: (query: { queryHash: string }) => boolean }
+      | undefined
+    expect(timeoutCancelFilters).toEqual(expect.objectContaining({ predicate: expect.any(Function) }))
+    const timeoutPredicate = timeoutCancelFilters?.predicate
+    expect(timeoutPredicate?.({ queryHash: hashQueryKey(['test-query']) })).toBe(true)
+    expect(timeoutPredicate?.({ queryHash: hashQueryKey(['other-query']) })).toBe(false)
     expect(screen.queryByText('Client Child')).not.toBeInTheDocument()
 
     const clientQueryClient = new QueryClient()
     render(<QueryClientProvider client={clientQueryClient}>{result}</QueryClientProvider>)
     expect(screen.getByTestId('client-only')).toBeInTheDocument()
     expect(screen.getByText('Client Child')).toBeInTheDocument()
+  })
+
+  it('should not cancel queries when error is not caused by timeout', async () => {
+    const serverQueryClient = new QueryClient()
+    const cancelQueriesSpy = vi.spyOn(serverQueryClient, 'cancelQueries')
+    const mockQueryFn = vi.fn().mockRejectedValue(new Error('Query failed immediately'))
+
+    await QueriesHydration({
+      queries: [
+        {
+          queryKey: ['test-query'],
+          queryFn: mockQueryFn,
+        },
+      ],
+      queryClient: serverQueryClient,
+      timeout: 1000,
+      children: <div>Client Child</div>,
+    })
+
+    expect(mockQueryFn).toHaveBeenCalledTimes(1)
+    expect(cancelQueriesSpy).not.toHaveBeenCalled()
+  })
+
+  it('should cancel all query keys when multiple queries timeout', async () => {
+    const serverQueryClient = new QueryClient()
+    const cancelQueriesSpy = vi.spyOn(serverQueryClient, 'cancelQueries')
+    const timeoutMs = 100
+    const queryDelayMs = 200
+    const slowQueryFn1 = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ data: 'test-data-1' }), queryDelayMs))
+      )
+    const slowQueryFn2 = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ data: 'test-data-2' }), queryDelayMs))
+      )
+
+    await QueriesHydration({
+      queries: [
+        {
+          queryKey: ['test-query-1'],
+          queryFn: slowQueryFn1,
+        },
+        {
+          queryKey: ['test-query-2'],
+          queryFn: slowQueryFn2,
+        },
+      ],
+      queryClient: serverQueryClient,
+      timeout: timeoutMs,
+      children: <div>Client Child</div>,
+    })
+
+    expect(slowQueryFn1).toHaveBeenCalledTimes(1)
+    expect(slowQueryFn2).toHaveBeenCalledTimes(1)
+    expect(cancelQueriesSpy).toHaveBeenCalledTimes(1)
+    const multiTimeoutCancelFilters = cancelQueriesSpy.mock.calls[0]?.[0] as
+      | { predicate?: (query: { queryHash: string }) => boolean }
+      | undefined
+    expect(multiTimeoutCancelFilters).toEqual(expect.objectContaining({ predicate: expect.any(Function) }))
+    const multiTimeoutPredicate = multiTimeoutCancelFilters?.predicate
+    expect(multiTimeoutPredicate?.({ queryHash: hashQueryKey(['test-query-1']) })).toBe(true)
+    expect(multiTimeoutPredicate?.({ queryHash: hashQueryKey(['test-query-2']) })).toBe(true)
+    expect(multiTimeoutPredicate?.({ queryHash: hashQueryKey(['other-query']) })).toBe(false)
   })
 })

--- a/packages/react-query-4/src/QueriesHydration.tsx
+++ b/packages/react-query-4/src/QueriesHydration.tsx
@@ -3,13 +3,20 @@ import {
   type HydrateProps,
   type OmitKeyof,
   QueryClient,
+  type QueryKey,
   type QueryOptions,
   type UseInfiniteQueryOptions,
   type WithRequired,
   dehydrate,
+  hashQueryKey,
 } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { ClientOnly } from './components/ClientOnly'
+
+type HydrationQuery = (
+  | WithRequired<QueryOptions<any, any, any, any>, 'queryKey'>
+  | WithRequired<UseInfiniteQueryOptions<any, any, any, any, any>, 'queryKey'>
+) & { queryKey: QueryKey }
 
 /**
  * A server component that fetches multiple queries on the server and hydrates them to the client.
@@ -91,10 +98,7 @@ export async function QueriesHydration({
    * An array of query options or infinite query options to be fetched on the server. Each query must include a `queryKey`.
    * You can mix regular queries and infinite queries in the same array.
    */
-  queries: (
-    | WithRequired<QueryOptions<any, any, any, any>, 'queryKey'>
-    | WithRequired<UseInfiniteQueryOptions<any, any, any, any, any>, 'queryKey'>
-  )[]
+  queries: HydrationQuery[]
   /**
    * Controls error handling behavior:
    * - `true` (default): Skips SSR and falls back to client-side rendering when server fetch fails
@@ -115,7 +119,7 @@ export async function QueriesHydration({
 } & OmitKeyof<HydrateProps, 'state'>) {
   const timeoutController =
     timeout != null && timeout >= 0
-      ? createTimeoutController(timeout, `QueriesHydration: timeout after ${timeout} ms)`)
+      ? createTimeoutController(timeout, `QueriesHydration: timeout after ${timeout} ms`)
       : undefined
   try {
     const queriesPromise = Promise.all(
@@ -124,14 +128,21 @@ export async function QueriesHydration({
       )
     )
     await (timeoutController != null ? Promise.race([queriesPromise, timeoutController.promise]) : queriesPromise)
-    timeoutController?.clear()
-  } catch {
-    timeoutController?.clear()
+  } catch (error) {
+    if (timeoutController?.isTimeoutError(error)) {
+      const timeoutQueryHashes = new Set(queries.map((query) => hashQueryKey(normalizeQueryKey(query.queryKey))))
+
+      void queryClient.cancelQueries({
+        predicate: (query) => timeoutQueryHashes.has(query.queryHash),
+      })
+    }
     if (skipSsrOnError) {
       return (
         <ClientOnly fallback={skipSsrOnError === true ? undefined : skipSsrOnError.fallback}>{children}</ClientOnly>
       )
     }
+  } finally {
+    timeoutController?.clear()
   }
   return (
     <Hydrate {...props} state={dehydrate(queryClient)}>
@@ -142,10 +153,14 @@ export async function QueriesHydration({
 
 const createTimeoutController = (ms: number, errorMessage: string) => {
   let timerId: ReturnType<typeof setTimeout> | undefined
+  const timeoutError = new Error(errorMessage)
   return {
     promise: new Promise<never>((_, reject) => {
-      timerId = setTimeout(() => reject(new Error(errorMessage)), ms)
+      timerId = setTimeout(() => reject(timeoutError), ms)
     }),
     clear: () => timerId != null && clearTimeout(timerId),
+    isTimeoutError: (error: unknown) => error === timeoutError,
   }
 }
+
+const normalizeQueryKey = (queryKey: unknown): QueryKey => (Array.isArray(queryKey) ? queryKey : [queryKey])

--- a/packages/react-query-5/src/QueriesHydration.spec.tsx
+++ b/packages/react-query-5/src/QueriesHydration.spec.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider, dehydrate, infiniteQueryOptions } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, dehydrate, hashKey, infiniteQueryOptions } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import type { ComponentProps, ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -357,6 +357,7 @@ describe('<QueriesHydration/>', () => {
 
   it('should timeout when query takes longer than the timeout', async () => {
     const serverQueryClient = new QueryClient()
+    const cancelQueriesSpy = vi.spyOn(serverQueryClient, 'cancelQueries')
     const timeoutMs = 100
     const queryDelayMs = 200
     const mockQueryFn = vi
@@ -384,11 +385,83 @@ describe('<QueriesHydration/>', () => {
     })
 
     expect(mockQueryFn).toHaveBeenCalledTimes(1)
+    expect(cancelQueriesSpy).toHaveBeenCalledTimes(1)
+    const timeoutCancelFilters = cancelQueriesSpy.mock.calls[0]?.[0]
+    expect(timeoutCancelFilters).toEqual(expect.objectContaining({ predicate: expect.any(Function) }))
+    const timeoutPredicate = timeoutCancelFilters?.predicate as ((query: { queryHash: string }) => boolean) | undefined
+    expect(timeoutPredicate?.({ queryHash: hashKey(['test-query']) })).toBe(true)
+    expect(timeoutPredicate?.({ queryHash: hashKey(['other-query']) })).toBe(false)
     expect(screen.queryByText('Client Child')).not.toBeInTheDocument()
 
     const clientQueryClient = new QueryClient()
     render(<QueryClientProvider client={clientQueryClient}>{result}</QueryClientProvider>)
     expect(screen.getByTestId('client-only')).toBeInTheDocument()
     expect(screen.getByText('Client Child')).toBeInTheDocument()
+  })
+
+  it('should not cancel queries when error is not caused by timeout', async () => {
+    const serverQueryClient = new QueryClient()
+    const cancelQueriesSpy = vi.spyOn(serverQueryClient, 'cancelQueries')
+    const mockQueryFn = vi.fn().mockRejectedValue(new Error('Query failed immediately'))
+
+    await QueriesHydration({
+      queries: [
+        {
+          queryKey: ['test-query'],
+          queryFn: mockQueryFn,
+        },
+      ],
+      queryClient: serverQueryClient,
+      timeout: 1000,
+      children: <div>Client Child</div>,
+    })
+
+    expect(mockQueryFn).toHaveBeenCalledTimes(1)
+    expect(cancelQueriesSpy).not.toHaveBeenCalled()
+  })
+
+  it('should cancel all query keys when multiple queries timeout', async () => {
+    const serverQueryClient = new QueryClient()
+    const cancelQueriesSpy = vi.spyOn(serverQueryClient, 'cancelQueries')
+    const timeoutMs = 100
+    const queryDelayMs = 200
+    const slowQueryFn1 = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ data: 'test-data-1' }), queryDelayMs))
+      )
+    const slowQueryFn2 = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ data: 'test-data-2' }), queryDelayMs))
+      )
+
+    await QueriesHydration({
+      queries: [
+        {
+          queryKey: ['test-query-1'],
+          queryFn: slowQueryFn1,
+        },
+        {
+          queryKey: ['test-query-2'],
+          queryFn: slowQueryFn2,
+        },
+      ],
+      queryClient: serverQueryClient,
+      timeout: timeoutMs,
+      children: <div>Client Child</div>,
+    })
+
+    expect(slowQueryFn1).toHaveBeenCalledTimes(1)
+    expect(slowQueryFn2).toHaveBeenCalledTimes(1)
+    expect(cancelQueriesSpy).toHaveBeenCalledTimes(1)
+    const multiTimeoutCancelFilters = cancelQueriesSpy.mock.calls[0]?.[0]
+    expect(multiTimeoutCancelFilters).toEqual(expect.objectContaining({ predicate: expect.any(Function) }))
+    const multiTimeoutPredicate = multiTimeoutCancelFilters?.predicate as
+      | ((query: { queryHash: string }) => boolean)
+      | undefined
+    expect(multiTimeoutPredicate?.({ queryHash: hashKey(['test-query-1']) })).toBe(true)
+    expect(multiTimeoutPredicate?.({ queryHash: hashKey(['test-query-2']) })).toBe(true)
+    expect(multiTimeoutPredicate?.({ queryHash: hashKey(['other-query']) })).toBe(false)
   })
 })

--- a/packages/react-query-5/src/QueriesHydration.tsx
+++ b/packages/react-query-5/src/QueriesHydration.tsx
@@ -3,13 +3,20 @@ import {
   type HydrationBoundaryProps,
   type OmitKeyof,
   QueryClient,
+  type QueryKey,
   type QueryOptions,
   type UseInfiniteQueryOptions,
   type WithRequired,
   dehydrate,
+  hashKey,
 } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { ClientOnly } from './components/ClientOnly'
+
+type HydrationQuery = (
+  | WithRequired<QueryOptions<any, any, any, any>, 'queryKey'>
+  | WithRequired<UseInfiniteQueryOptions<any, any, any, any, any>, 'queryKey'>
+) & { queryKey: QueryKey }
 
 /**
  * A server component that fetches multiple queries on the server and hydrates them to the client.
@@ -87,10 +94,7 @@ export async function QueriesHydration({
    * An array of query options or infinite query options to be fetched on the server. Each query must include a `queryKey`.
    * You can mix regular queries and infinite queries in the same array.
    */
-  queries: (
-    | WithRequired<QueryOptions<any, any, any, any>, 'queryKey'>
-    | WithRequired<UseInfiniteQueryOptions<any, any, any, any, any>, 'queryKey'>
-  )[]
+  queries: HydrationQuery[]
   /**
    * Controls error handling behavior:
    * - `true` (default): Skips SSR and falls back to client-side rendering when server fetch fails
@@ -111,7 +115,7 @@ export async function QueriesHydration({
 } & OmitKeyof<HydrationBoundaryProps, 'state'>) {
   const timeoutController =
     timeout != null && timeout >= 0
-      ? createTimeoutController(timeout, `QueriesHydration: timeout after ${timeout} ms)`)
+      ? createTimeoutController(timeout, `QueriesHydration: timeout after ${timeout} ms`)
       : undefined
   try {
     const queriesPromise = Promise.all(
@@ -120,14 +124,21 @@ export async function QueriesHydration({
       )
     )
     await (timeoutController != null ? Promise.race([queriesPromise, timeoutController.promise]) : queriesPromise)
-    timeoutController?.clear()
-  } catch {
-    timeoutController?.clear()
+  } catch (error) {
+    if (timeoutController?.isTimeoutError(error)) {
+      const timeoutQueryHashes = new Set(queries.map((query) => hashKey(normalizeQueryKey(query.queryKey))))
+
+      void queryClient.cancelQueries({
+        predicate: (query) => timeoutQueryHashes.has(query.queryHash),
+      })
+    }
     if (skipSsrOnError) {
       return (
         <ClientOnly fallback={skipSsrOnError === true ? undefined : skipSsrOnError.fallback}>{children}</ClientOnly>
       )
     }
+  } finally {
+    timeoutController?.clear()
   }
   return (
     <HydrationBoundary {...props} state={dehydrate(queryClient)}>
@@ -138,10 +149,14 @@ export async function QueriesHydration({
 
 const createTimeoutController = (ms: number, errorMessage: string) => {
   let timerId: ReturnType<typeof setTimeout> | undefined
+  const timeoutError = new Error(errorMessage)
   return {
     promise: new Promise<never>((_, reject) => {
-      timerId = setTimeout(() => reject(new Error(errorMessage)), ms)
+      timerId = setTimeout(() => reject(timeoutError), ms)
     }),
     clear: () => timerId != null && clearTimeout(timerId),
+    isTimeoutError: (error: unknown) => error === timeoutError,
   }
 }
+
+const normalizeQueryKey = (queryKey: unknown): QueryKey => (Array.isArray(queryKey) ? queryKey : [queryKey])


### PR DESCRIPTION
# Overview

This PR improves `QueriesHydration` timeout handling in both `@suspensive/react-query-4` and `@suspensive/react-query-5`.

## What changed

- Cancel only timed-out hydration queries with a single `cancelQueries` call using `predicate` + `queryHash` set matching.
- Distinguish timeout errors from non-timeout query errors via a stable timeout error instance (`isTimeoutError`).
- Keep timeout cleanup in `finally` for all execution paths.
- Add/extend tests to verify:
  - cancellation happens on timeout,
  - cancellation is skipped for non-timeout errors,
  - multiple timed-out queries are all covered by the predicate.

## Validation

- `corepack pnpm --filter @suspensive/react-query-5 exec eslint src/QueriesHydration.tsx src/QueriesHydration.spec.tsx`
- `corepack pnpm --filter @suspensive/react-query-4 exec eslint src/QueriesHydration.tsx src/QueriesHydration.spec.tsx`
- `corepack pnpm --filter @suspensive/react-query-5 ci:test -- src/QueriesHydration.spec.tsx`
- `corepack pnpm --filter @suspensive/react-query-4 ci:test -- src/QueriesHydration.spec.tsx`

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
