### PR TITLE
ci(.github/workflows/autofix): use conventional commits format for 'commit-message'

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -23,3 +23,5 @@ jobs:
       - run: pnpm prettier --write .
       - run: pnpm run packlint
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2
+        with:
+          commit-message: 'ci: apply automated fixes'


### PR DESCRIPTION
# Overview

Set `commit-message` in `autofix-ci/action` to `'ci: apply automated fixes'` to follow Conventional Commits format instead of the default `[autofix.ci] apply automated fixes`.

## PR Checklist

- [ ] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.