### PR TITLE
fix(docs): make code block copy button visible in light mode

### DIFF
--- a/docs/suspensive.org/src/app/[lang]/styles.css
+++ b/docs/suspensive.org/src/app/[lang]/styles.css
@@ -34,6 +34,10 @@ pre {
   @apply rounded-lg bg-zinc-900;
 }
 
+pre button {
+  @apply text-white;
+}
+
 .dark pre {
   @apply border-gray-900 bg-inherit;
 }


### PR DESCRIPTION
# Overview
In light mode, the copy button icon inside code blocks was invisible because the button color followed the light theme (black) while the code block background is always dark (`bg-zinc-900`).

Added `pre button { @apply text-white; }` to `styles.css` to ensure the copy button is always visible against the dark background.

#1936 


<img width="804" height="354" alt="image" src="https://github.com/user-attachments/assets/3ca6441d-120b-4d5f-9f3c-5cbc9e4389c8" />


## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
