### PR TITLE
fix(react-query-4,react-query-5): disable retry in QueriesHydration s…

### DIFF
--- a/packages/react-query-4/src/QueriesHydration.tsx
+++ b/packages/react-query-4/src/QueriesHydration.tsx
@@ -117,7 +117,9 @@ export async function QueriesHydration({
   try {
     const queriesPromise = Promise.all(
       queries.map((query) =>
-        'getNextPageParam' in query ? queryClient.fetchInfiniteQuery(query) : queryClient.fetchQuery(query)
+        'getNextPageParam' in query
+          ? queryClient.fetchInfiniteQuery({ ...query, retry: 0 })
+          : queryClient.fetchQuery({ ...query, retry: 0 })
       )
     )
     await (timeoutController != null ? Promise.race([queriesPromise, timeoutController.promise]) : queriesPromise)

--- a/packages/react-query-5/src/QueriesHydration.tsx
+++ b/packages/react-query-5/src/QueriesHydration.tsx
@@ -113,7 +113,9 @@ export async function QueriesHydration({
   try {
     const queriesPromise = Promise.all(
       queries.map((query) =>
-        'getNextPageParam' in query ? queryClient.fetchInfiniteQuery(query) : queryClient.fetchQuery(query)
+        'getNextPageParam' in query
+          ? queryClient.fetchInfiniteQuery({ ...query, retry: 0 })
+          : queryClient.fetchQuery({ ...query, retry: 0 })
       )
     )
     await (timeoutController != null ? Promise.race([queriesPromise, timeoutController.promise]) : queriesPromise)


### PR DESCRIPTION
Hi Suspensive team,
Thanks for the great library!

# Overview
Issue #1895

### What

Force retry: 0 when calling fetchQuery and fetchInfiniteQuery in QueriesHydration.

### Why

If retries occur during server-side prefetching, the server component rendering becomes blocked for each retry attempt.

### How
Explicitly set `retry` to `0` for all query calls:

fetchQuery({ ...query, retry: 0 })
fetchInfiniteQuery({ ...query, retry: 0 })

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
