### PR TITLE
fix(jotai): add children to SetAtom overload signatures

### DIFF
--- a/.changeset/twelve-dragons-agree.md
+++ b/.changeset/twelve-dragons-agree.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/jotai": patch
+---
+
+fix(jotai): add children to SetAtom overload signatures

--- a/packages/jotai/src/SetAtom.tsx
+++ b/packages/jotai/src/SetAtom.tsx
@@ -33,11 +33,13 @@ type UseSetAtomProps<TAtom> = {
  * ```
  */
 export function SetAtom<TValue, TArgs extends unknown[], TResult>({
+  children,
   atom,
   options,
 }: UseSetAtomProps<WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>): ReactNode
 
 export function SetAtom<TAtom extends WritableAtom<unknown, never[], unknown>>({
+  children,
   atom,
   options,
 }: UseSetAtomProps<TAtom> & ChildrenRenderProps<TSetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>>): ReactNode


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

 ## Problem                                                                                                                                             
                                                                                                                                                         
  The overload signatures of `SetAtom` did not include `children` in their destructured parameters, unlike `Atom` and `AtomValue` which consistently     
  destructure `children` in all overload signatures.                                                                                                     
                                                                                                                                                         
  This creates two concrete issues:                                                                                                                      
                                                                                                                                                       
  1. **IDE hover signature does not show `children`** — when hovering over `SetAtom` in an editor, `children` is not visible in the displayed signature, 
  making it less discoverable compared to `Atom` and `AtomValue`.                                                                                      
  2. **Inconsistent pattern within the package** — all three components follow the render props pattern, but only `SetAtom` omits `children` from its    
  overload declarations, breaking the expected reading flow and overall code coherence.                                                                  
                                                                                                                                                       
**Before (`SetAtom.tsx`)**                                                                                                                             
```tsx                                                                                                                                               
// ❌ Overload 1 — children missing                                                                                                                  
export function SetAtom<TValue, TArgs extends unknown[], TResult>({                                                                                    
  atom,
  options,                                                                                                                                             
}: UseSetAtomProps<WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>): ReactNode                                 
                                                                                                                                                       
// ❌ Overload 2 — children missing
export function SetAtom<TAtom extends WritableAtom<unknown, never[], unknown>>({                                                                       
  atom,                                                                                                                                                
  options,                                                                                                                                           
}: UseSetAtomProps<TAtom> & ChildrenRenderProps<TSetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>>): ReactNode                                
                                                                                                                                                       
// ✅ Implementation — children present (only here)                                                                                                    
export function SetAtom<TValue, TArgs extends unknown[], TResult>({                                                                                    
  children,                                                                                                                                            
  atom,                                                                                                                                              
  options,                                                                                                                                           
}: ...): ReactNode {
  return <>{children(useSetAtom(atom, options))}</>
}                                                                                                                                                      
```
**Atom and AtomValue (consistent pattern)**                                                                                                           

```tsx
// ✅ AtomValue — children included in all overload signatures                                                                                       
export function AtomValue<TValue>({                                                                                                                    
  children,                                                                                                                                          
  atom,                                                                                                                                                
  options,
}: UseAtomValueProps<JotaiAtom<TValue>> & ChildrenRenderProps<Awaited<TValue>>): ReactNode                                                             
                                                                                                                                                     
export function AtomValue<TAtom extends JotaiAtom<unknown>>({                                                                                          
  children,                                                  
  atom,                                                                                                                                                
  options,                                                                                                                                           
}: UseAtomValueProps<TAtom> & ChildrenRenderProps<Awaited<ExtractAtomValue<TAtom>>>): ReactNode                                                      
```

## Solution                                                                                                                                               
   
Add children to both overload signatures of SetAtom to align with the pattern used by Atom and AtomValue.                                              

**After (`SetAtom.tsx`)**
```tsx                                                                                                                                                                                                                                                                                           
  // ✅ Overload 1 — children added                                                                                                                    
  export function SetAtom<TValue, TArgs extends unknown[], TResult>({                                                                                  
    children,                                                        
    atom,                                                                                                                                                
    options,
  }: UseSetAtomProps<WritableAtom<TValue, TArgs, TResult>> & ChildrenRenderProps<TSetAtom<TArgs, TResult>>): ReactNode                                   
                                                                                                                                                       
  // ✅ Overload 2 — children added                                                                                                                      
  export function SetAtom<TAtom extends WritableAtom<unknown, never[], unknown>>({
    children,                                                                                                                                            
    atom,                                                                                                                                              
    options,                                                                                                                                           
  }: UseSetAtomProps<TAtom> & ChildrenRenderProps<TSetAtom<ExtractAtomArgs<TAtom>, ExtractAtomResult<TAtom>>>): ReactNode
```
                                                                                                                                                  
## Notes
                                                                                                                                               
  - No runtime behavior change                                                                                                                           
  - No type system change (children was already required via & ChildrenRenderProps<...>)                                                               
  - Pure consistency fix to match Atom and AtomValue overload patterns 

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
