### PR TITLE
fix(react-query-4): add void operator to floating promises

### DIFF
--- a/.changeset/eleven-ants-behave.md
+++ b/.changeset/eleven-ants-behave.md
@@ -1,0 +1,5 @@
+---
+"@suspensive/react-query-4": patch
+---
+
+fix(react-query-4): add void operator to floating promises

--- a/packages/react-query-4/src/usePrefetchInfiniteQuery.ts
+++ b/packages/react-query-4/src/usePrefetchInfiniteQuery.ts
@@ -14,6 +14,6 @@ export function usePrefetchInfiniteQuery<
   const queryClient = useQueryClient()
 
   if (typeof options.queryKey !== 'undefined' && !queryClient.getQueryState(options.queryKey)) {
-    queryClient.prefetchInfiniteQuery(options)
+    void queryClient.prefetchInfiniteQuery(options)
   }
 }

--- a/packages/react-query-4/src/usePrefetchQuery.ts
+++ b/packages/react-query-4/src/usePrefetchQuery.ts
@@ -14,6 +14,6 @@ export function usePrefetchQuery<
   const queryClient = useQueryClient()
 
   if (typeof options.queryKey !== 'undefined' && !queryClient.getQueryState(options.queryKey)) {
-    queryClient.prefetchQuery(options)
+    void queryClient.prefetchQuery(options)
   }
 }


### PR DESCRIPTION
# Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Added `void` operator to fire-and-forget promise calls in `usePrefetchQuery` and `usePrefetchInfiniteQuery` hooks to resolve `@typescript-eslint/no-floating-promises` eslint warnings.
                                                                                
## Changes                         
- `usePrefetchQuery.ts`: `queryClient.prefetchQuery(options)` → `void queryClient.prefetchQuery(options)`                                         
- `usePrefetchInfiniteQuery.ts`: `queryClient.prefetchInfiniteQuery(options)` → `void queryClient.prefetchInfiniteQuery(options)`                          
                                                                                
## Motivation                                
These hooks intentionally fire prefetch calls without awaiting the result, but the `void` operator was missing. This is inconsistent with `QueriesHydration.tsx` where `void queryClient.cancelQueries()` is already correctly applied.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
