### PR TITLE
fix(suspensive.org/Sandpack): exclude custom props from 'SandpackPreview' spread to prevent DOM warnings

### DIFF
--- a/docs/suspensive.org/src/components/Sandpack/CustomPreset.tsx
+++ b/docs/suspensive.org/src/components/Sandpack/CustomPreset.tsx
@@ -25,18 +25,22 @@ export const CustomPreset = (
     'layoutOptions' | 'editorOptions' | 'previewOptions'
   >
 ) => {
+  const {
+    layout,
+    showConsole: showConsoleProp,
+    showConsoleButton: showConsoleButtonProp,
+    ...restPreviewOptions
+  } = props.previewOptions ?? {}
+  const mode = layout ?? 'preview'
+  const showConsole = showConsoleProp ?? false
+  const showConsoleButton = showConsoleButtonProp ?? false
+
   const dragEventTargetRef = useRef<(EventTarget & HTMLDivElement) | null>(null)
 
   const [horizontalSize, setHorizontalSize] = useState(50)
   const [verticalSize, setVerticalSize] = useState(60)
-  const [consoleVisibility, setConsoleVisibility] = useState(
-    props.previewOptions?.showConsole ?? false
-  )
+  const [consoleVisibility, setConsoleVisibility] = useState(showConsole)
   const [counter, setCounter] = useState(0)
-
-  const mode = props.previewOptions?.layout ?? 'preview'
-  const showConsole = props.previewOptions?.showConsole ?? false
-  const showConsoleButton = props.previewOptions?.showConsoleButton ?? false
 
   const hasRightColumn = showConsole || showConsoleButton
   const RightColumn = hasRightColumn ? SandpackStack : Fragment
@@ -152,7 +156,7 @@ export const CustomPreset = (
             showSandpackErrorOverlay={false}
             actionsChildren={actionsChildren}
             style={topRowStyle}
-            {...props.previewOptions}
+            {...restPreviewOptions}
           >
             <ErrorOverlay />
           </SandpackPreview>


### PR DESCRIPTION
# Overview

- Destructure custom props (`layout`, `showConsole`, `showConsoleButton`) from `previewOptions` before spreading to `SandpackPreview`
- These props are not part of `PreviewProps` but were passed to the DOM via `{...props.previewOptions}`, causing React warnings:
  - `showConsoleButton` prop on a DOM element
  - `showConsole` prop on a DOM element
  
## Screenshot

### AS-IS

<img width="1725" height="939" alt="image" src="https://github.com/user-attachments/assets/154ac894-6583-4936-886f-e339f3a05b9e" />
<img width="1727" height="943" alt="image" src="https://github.com/user-attachments/assets/5ca2a958-d762-4691-bcc0-aeed366edc48" />
<img width="1728" height="942" alt="image" src="https://github.com/user-attachments/assets/58cb5088-ca16-4124-83d7-00ae5601ef5c" />

### TO-BE

<img width="1724" height="939" alt="image" src="https://github.com/user-attachments/assets/a4cb8d82-2727-408f-8a40-f2f485354adf" />

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.