### PR TITLE
fix: Inconsistent UI Rendering When System is in Light Mode

### DIFF
--- a/docs/suspensive.org/src/app/[lang]/styles.css
+++ b/docs/suspensive.org/src/app/[lang]/styles.css
@@ -1,6 +1,9 @@
 @import 'tailwindcss';
 @import 'nextra-theme-docs/style.css';
 
+/* tailWind가 OS의 테마 설정이 아닌, HTML 내의 dark 클래스를 참조하도록 설정 */
+@custom-variant dark (&:where(.dark, .dark *));
+
 .scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;


### PR DESCRIPTION
# Overview
After removing Light Mode and setting the default background to dark, a color mismatch occurs when the system is set to Light Mode.

Some UI elements (such as text, tables, and highlights) still follow Light Mode styles, resulting in poor contrast and reduced readability against the dark background.

Tailwind’s dark: variant applies styles based on the OS color scheme. As a result, dark: classes were ignored when the system was in Light Mode.

Since next-themes already applies a dark class to the <html> element via forcedTheme, we introduced a custom dark variant so that Tailwind references this class instead. This ensures that dark mode styles are always applied regardless of the system setting.

## PR Checklist

- [x] I did below actions if need

1. I read the [Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.
