### PR TITLE
fix: Improve accessibility for links without accessible labels (#1972)

### DIFF
--- a/docs/suspensive.org/src/components/FeatureGrid.tsx
+++ b/docs/suspensive.org/src/components/FeatureGrid.tsx
@@ -214,7 +214,11 @@ function FeatureCard({
           ease: 'linear',
         }}
       />
-      <Link href={item.href} className="absolute inset-0 z-10" />
+      <Link
+        href={item.href}
+        aria-label={item.title}
+        className="absolute inset-0 z-10"
+      />
       <h3 className="mb-2 font-mono text-sm font-semibold tracking-tight">
         {item.title}
       </h3>


### PR DESCRIPTION
# Overview

This PR improves accessibility for links used in the `FeatureGrid` component by adding accessible labels (`aria-label`) to unlabeled links.

This helps screen reader users navigate links more effectively and resolves accessibility audit warnings related to missing accessible names.

## PR Checklist

* [x] I did below actions if need

1. I read the [[Contributing Guide](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)](https://github.com/toss/suspensive/blob/main/CONTRIBUTING.md)
2. I added documents and tests.